### PR TITLE
Correct keybindings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ ext install heliax.juvix-mode
 
 | Command   |               Keymap                |
 | :-------- | :---------------------------------: |
-| typecheck | <kbd>Ctrl-k</kbd> <kbd>Ctrl-l</kbd> |
-| compile   | <kbd>Ctrl-k</kbd> <kbd>Ctrl-c</kbd> |
-| run       | <kbd>Ctrl-k</kbd> <kbd>Ctrl-r</kbd> |
+| typecheck | <kbd>Ctrl+Shift+T</kbd> |
+| compile   | <kbd>Ctrl+Shift+C</kbd> |
+| run       | <kbd>Ctrl+Shift+R</kbd> |
+| doctor    | <kbd>Ctrl+Shift+D</kbd> |
 
 Find out other commands in the Command Pallete.
 


### PR DESCRIPTION
This change corrects the mentioned keybindings in the README as follows:
1. We use the ones that are actually in this package's contributions ---namely, https://github.com/anoma/vscode-juvix/blob/main/package.json#L246
2. We use the capitalization-with-`+` keybinding convention of the VSCode community ---see these VSCode docs for examples: https://code.visualstudio.com/docs/introvideos/basics
     - The existing README uses the `-`-style of the Emacs community
3. Finally, we document another useful command: `juvix doctor`