### PR TITLE
refactor(extension): Rename juvix command name internal -> dev

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -6,8 +6,8 @@
   - [x] compile (ctrl+c ctrl+c)
   - [x] run (ctrl+c ctrl+r)
   - [x] html
-  - [x] internal parse
-  - [x] internal scope
+  - [x] dev parse
+  - [x] dev scope
 
 - Context menu (right-click) showing:
 

--- a/package.json
+++ b/package.json
@@ -231,14 +231,14 @@
         "when": "editorLangId == Juvix && editorTextFocus"
       },
       {
-        "command": "juvix-mode.internal-parse",
-        "title": "[internal] parse",
+        "command": "juvix-mode.dev-parse",
+        "title": "dev parse",
         "category": "Juvix",
         "when": "editorLangId == Juvix && editorTextFocus"
       },
       {
-        "command": "juvix-mode.internal-scope",
-        "title": "[internal] scope",
+        "command": "juvix-mode.dev-scope",
+        "title": "dev scope",
         "category": "Juvix",
         "when": "editorLangId == Juvix && editorTextFocus"
       }

--- a/src/highlighting.ts
+++ b/src/highlighting.ts
@@ -63,7 +63,7 @@ interface FaceProperty {
   tokenType: string;
 }
 
-interface InternalHighlightOutput {
+interface DevHighlightOutput {
   face: [Array<Array<string | number> | string>];
   goto: [[string, number, number, number], string, number, number][];
 }
@@ -80,7 +80,7 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
     const { spawnSync } = require('child_process');
     const ls = spawnSync(
       config.getJuvixExec(),
-      ['internal', 'highlight', '--format', 'json', filePath, '--stdin'],
+      ['dev', 'highlight', '--format', 'json', filePath, '--stdin'],
       { input: content }
     );
 
@@ -90,7 +90,7 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
       throw new Error(errMsg);
     }
     const stdout = ls.stdout;
-    const output: InternalHighlightOutput = JSON.parse(stdout.toString());
+    const output: DevHighlightOutput = JSON.parse(stdout.toString());
     const allTokens = output.face;
 
     defLocation.set(filePath, new Map());

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -68,13 +68,13 @@ export class JuvixTaskProvider implements vscode.TaskProvider {
         reveal: vscode.TaskRevealKind.Always,
       },
       {
-        command: 'internal parse',
+        command: 'dev parse',
         args: ['${file}', config.getGlobalFlags()],
         group: vscode.TaskGroup.Build,
         reveal: vscode.TaskRevealKind.Always,
       },
       {
-        command: 'internal scope',
+        command: 'dev scope',
         args: ['${file}', config.getGlobalFlags()],
         group: vscode.TaskGroup.Build,
         reveal: vscode.TaskRevealKind.Always,


### PR DESCRIPTION
The juvenix command name `internal` was renamed into `dev` in https://github.com/anoma/juvix/pull/1420.