### PR TITLE
Fixes input-method issue and add repl improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,10 @@
 # Adapted from https://github.com/HaaLeo/vscode-timing/.github/workflows/cicd.yml
-name: Build, Lint, Test and Deploy
+name: Build, Lint, and Deploy
 
 on:
   push:
     branches:
-      - "*"
+      - '*'
   pull_request:
     branches:
       - master

--- a/README.md
+++ b/README.md
@@ -64,13 +64,12 @@ properly.
 | :-------- | :--------------------: |
 | typecheck | <kbd>Shift+Alt+T</kbd> |
 | compile   | <kbd>Shift+Alt+C</kbd> |
-| run       | <kbd>Shift+Alt+L</kbd> |
+| run       | <kbd>Shift+Alt+X</kbd> |
+| repl      | <kbd>Shift+Alt+L</kbd> |
 | doctor    | <kbd>Shift+Alt+D</kbd> |
 
 However, we recommend using the Command Palette (<kbd>Ctrl</kbd><kbd>P</kbd>) to
-see which other commands are available. You can also use the Command Palette to
-run any of the commands above. To do so, type `Juvix` and select the command you
-want to run.
+see which other commands are available by typing `Juvix` and select the command you want to run.
 
 ## Configuration
 
@@ -82,6 +81,6 @@ settings.
 - Command palette with typechecking, compilation, and running Juvix files.
 - Semantic syntax highlighting.
 - Support for light and dark themes.
-- Support for Unicode input (e.g. λ, Π, Σ, etc.), as pressing <kbd>\</kbd> + `alpha` to type α.
+- Support for Unicode input (e.g. λ, Π, Σ, etc.) pressing e.g. `\` + "alpha" + `space`.
 - Support for user configuration options.
 - Support for Juvix's REPL.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juvix-mode",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "GPL-3.0",
   "description": "Juvix IDE support for VSCode",
   "displayName": "Juvix",
@@ -302,7 +302,7 @@
         "when": "editorLangId == Juvix && editorTextFocus"
       },
       {
-        "command": "juvix-mode.repl",
+        "command": "juvix-mode.loadFileRepl",
         "title": "Load file in REPL",
         "category": "Juvix",
         "when": "editorLangId == Juvix && editorTextFocus"
@@ -347,7 +347,7 @@
       },
       {
         "key": "shift+alt+l",
-        "command": "juvix-mode.repl",
+        "command": "juvix-mode.loadFileRepl",
         "args": "Juvix: repl",
         "when": "(editorLangId == Juvix || editorLangId == JuvixCore)  && editorTextFocus"
       },
@@ -410,13 +410,13 @@
           "type": "string",
           "default": "juvix",
           "scope": "machine-overridable",
-          "description": "Name of the executable of Juvix. e.g. juvix-0.2.0"
+          "description": "Name of the executable of Juvix. (e.g. juvix-v0.3.0)"
         },
         "juvix-mode.bin.path": {
           "type": "string",
           "default": "",
           "scope": "machine-overridable",
-          "description": "Path to the executable of Juvix. e.g. /usr/local/bin/"
+          "description": "Absolute path to the executable of Juvix. (e.g. /usr/local/bin/)"
         },
         "juvix-mode.revealPanel": {
           "type": "string",
@@ -480,9 +480,10 @@
         },
         "juvix-mode.compilationTarget": {
           "type": "string",
+          "default": "",
           "enum": [
-            "c",
             "native",
+            "c",
             "wasm",
             "html"
           ],
@@ -504,7 +505,7 @@
         "juvix-mode.compilationOutputFile": {
           "type": "string",
           "scope": "machine-overridable",
-          "description": "File name for the compiled file"
+          "description": "Path to the output file (-o --output)."
         },
         "juvix-mode.input.enabled": {
           "type": "boolean",

--- a/src/abbreviation/rewriter/AbbreviationRewriter.ts
+++ b/src/abbreviation/rewriter/AbbreviationRewriter.ts
@@ -45,11 +45,10 @@ export class AbbreviationRewriter {
   constructor(
     private readonly config: AbbreviationConfig,
     private readonly abbreviationProvider: AbbreviationProvider,
-    private readonly textEditor: TextEditor
+    private readonly textEditor: TextEditor,
+    private readonly stderrOutputChannel: OutputChannel
   ) {
-    //   debug.log('info', workspace.name);
-    //   debug.log('info', workspace.getWorkspaceFolder(textEditor.document.uri));
-
+    this.stderrOutput = stderrOutputChannel;
     this.disposables.push(this.decorationType);
 
     this.disposables.push(
@@ -63,10 +62,7 @@ export class AbbreviationRewriter {
         // Otherwise, changes at the top will move spans at the bottom down.
         changes.sort((c1, c2) => c2.rangeOffset - c1.rangeOffset);
 
-        // debug.log('info', 'changes:' + (changesCounter++).toString());
-
         for (const c of changes) {
-          // debug.log('info', c.text);
           const range = new Range(c.rangeOffset, c.rangeLength);
           this.processChange(range, c.text);
         }
@@ -105,7 +101,6 @@ export class AbbreviationRewriter {
     );
 
     this.disposables.push(
-      // TODO: if( ! commands.getCommands().includes('juvix-mode.input.convert') )
       commands.registerTextEditorCommand('juvix-mode.input.convert', async () =>
         this.forceReplace([...this.trackedAbbreviations])
       )

--- a/src/abbreviation/rewriter/AbbreviationRewriterFeature.ts
+++ b/src/abbreviation/rewriter/AbbreviationRewriterFeature.ts
@@ -4,6 +4,7 @@
 import { observable } from 'mobx';
 import { Disposable, languages, TextEditor, window } from 'vscode';
 import { autorunDisposable } from '../../utils/autorunDisposable';
+import { debugChannel } from '../../utils/debug';
 import { AbbreviationProvider } from '../AbbreviationProvider';
 import { AbbreviationConfig } from '../config';
 import { AbbreviationRewriter } from './AbbreviationRewriter';
@@ -40,7 +41,8 @@ export class AbbreviationRewriterFeature {
             new AbbreviationRewriter(
               config,
               abbreviationProvider,
-              this.activeTextEditor
+              this.activeTextEditor,
+              debugChannel
             )
           );
         }

--- a/src/highlighting.ts
+++ b/src/highlighting.ts
@@ -190,17 +190,4 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
     }
     return 0;
   }
-
-  private encodeTokenModifiers(strTokenModifiers: string[]): number {
-    let result = 0;
-    for (let i = 0; i < strTokenModifiers.length; i++) {
-      const tokenModifier = strTokenModifiers[i];
-      if (tokenModifiers.has(tokenModifier)) {
-        result = result | (1 << tokenModifiers.get(tokenModifier)!);
-      } else if (tokenModifier === 'notInLegend') {
-        result = result | (1 << (tokenModifiers.size + 2));
-      }
-    }
-    return result;
-  }
 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -17,79 +17,59 @@ import { autorunDisposable } from './utils/autorunDisposable';
 import { Disposable, languages, TextEditor, window } from 'vscode';
 import { observable } from 'mobx';
 import { debugChannel } from './utils/debug';
+import { debug } from 'console';
 
 export function activate(context: vscode.ExtensionContext) {
-  const config = new AbbreviationConfig();
-  const trans = new AbbreviationProvider(config);
-  const hover = autorunDisposable(disposables => {
-    disposables.push(
-      vscode.languages.registerHoverProvider(
-        config.languages.get(),
-        new AbbreviationHoverProvider(config, trans)
-      )
-    );
-  });
-  context.subscriptions.push(hover);
-  debugChannel.info('Hover input information added');
-  context.subscriptions.push(new AbbreviationRewriterFeature(config, trans));
+  context.subscriptions.push(new Abbr());
   debugChannel.info('Abbreviation rewriter registered');
 }
 
-/**
- * Sets up everything required for the abbreviation rewriter feature.
- * Creates an `AbbreviationRewriter` for the active editor.
- */
-export class AbbreviationRewriterFeature {
-  public readonly disposables = new Array<Disposable>();
-  private readonly config: AbbreviationConfig;
-  private readonly abbreviationProvider: AbbreviationProvider;
+class Abbr {
+  private readonly disposables = new Array<Disposable>();
+  private readonly config: AbbreviationConfig; // TODO: unify with JuvixConfig
+  private readonly table: AbbreviationProvider;
 
-  @observable
-  private activeTextEditor: TextEditor | undefined;
+  constructor() {
+    this.config = new AbbreviationConfig();
+    this.table = new AbbreviationProvider(this.config);
+    const autorun = autorunDisposable(disposables => {
+      disposables.push(
+        vscode.languages.registerHoverProvider(
+          this.config.languages.get(),
+          new AbbreviationHoverProvider(this.config, this.table)
+        )
+      );
+    });
+    this.disposables.push(autorun);
 
-  constructor(
-    private readonly c: AbbreviationConfig,
-    abbreviationProvider: AbbreviationProvider
-  ) {
-    this.activeTextEditor = window.activeTextEditor;
-    this.config = c;
-    this.abbreviationProvider = abbreviationProvider;
-    this.disposables.push(
-      autorunDisposable(ds => {
-        ds.push(
-          window.onDidChangeActiveTextEditor(e => {
-            if (e) {
-              this.activeTextEditor = e;
-              this.activate();
-            }
-          })
+    const currentEditor = window.activeTextEditor;
+    let rewriter: AbbreviationRewriter | undefined = undefined;
+    if (currentEditor && this.shouldEnableRewriterForEditor(currentEditor)) {
+      rewriter = new AbbreviationRewriter(
+        this.config,
+        this.table,
+        currentEditor,
+        debugChannel
+      );
+      this.disposables.push(rewriter);
+    }
+    const changeEditor = vscode.window.onDidChangeActiveTextEditor(editor => {
+      if (editor && this.shouldEnableRewriterForEditor(editor)) {
+        rewriter?.dispose();
+        rewriter = new AbbreviationRewriter(
+          this.config,
+          this.table,
+          editor,
+          debugChannel
         );
-      })
-    );
-    this.activate();
+        this.disposables.push(rewriter);
+      }
+    });
+    this.disposables.push(changeEditor);
+  
   }
 
-  public activate(): void {
-    this.disposables.push(
-      autorunDisposable(disposables => {
-        if (
-          this.activeTextEditor &&
-          this.shouldEnableRewriterForEditor(this.activeTextEditor)
-        ) {
-          // This creates an abbreviation rewriter for the active text editor.
-          // Old rewriters are disposed automatically.
-          // This is also updated when this feature is turned off/on.
-          const rewriter = new AbbreviationRewriter(
-            this.config,
-            this.abbreviationProvider,
-            this.activeTextEditor
-          );
-          disposables.push(rewriter);
-        }
-      })
-    );
-  }
-  private shouldEnableRewriterForEditor(editor: TextEditor): boolean {
+  shouldEnableRewriterForEditor(editor: TextEditor): boolean {
     if (!this.config.inputModeEnabled) {
       return false;
     }
@@ -100,8 +80,6 @@ export class AbbreviationRewriterFeature {
   }
 
   dispose(): void {
-    for (const d of this.disposables) {
-      d.dispose();
-    }
+    this.disposables.forEach(d => d.dispose());
   }
 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -66,7 +66,6 @@ class Abbr {
       }
     });
     this.disposables.push(changeEditor);
-  
   }
 
   shouldEnableRewriterForEditor(editor: TextEditor): boolean {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -33,7 +33,7 @@ export class JuvixRepl {
       name: terminalName,
       cwd: path.dirname(document.fileName),
       isTransient: false,
-      shellPath : '/usr/bin/bash',
+      shellPath: '/usr/bin/bash',
       location: {
         viewColumn: vscode.ViewColumn.Beside,
         preserveFocus: true,
@@ -99,7 +99,8 @@ export class JuvixRepl {
       debugChannel.error('Unknown language');
       return;
     }
-    const ready: Promise<vscode.TerminalExitStatus> = this.promiseCall(shellCmd);
+    const ready: Promise<vscode.TerminalExitStatus> =
+      this.promiseCall(shellCmd);
     ready.then(status => {
       if (status.code == 0) {
         vscode.window.showInformationMessage('Juvix REPL ready');

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -41,7 +41,7 @@ export class JuvixRepl {
     };
     debugChannel.info('options: ' + JSON.stringify(options));
     this.terminal = vscode.window.createTerminal(options);
-    this.callInitCmd();
+    this.openRepl();
 
     const reloadFile = vscode.workspace.onDidSaveTextDocument(d => {
       if (d === document && this.config.reloadReplOnSave.get()) {
@@ -76,11 +76,9 @@ export class JuvixRepl {
         async closedTerminal => {
           if (closedTerminal === this.terminal) {
             disposeToken.dispose();
-            if (this.terminal.exitStatus !== undefined) {
+            if (this.terminal.exitStatus !== undefined)
               resolve(this.terminal.exitStatus);
-            } else {
-              reject('Terminal exited with undefined status');
-            }
+            else reject('Terminal exited with undefined status');
           }
         }
       );
@@ -88,7 +86,7 @@ export class JuvixRepl {
   }
 
   /* Open the REPL for the current file */
-  public callInitCmd() {
+  public openRepl(): void {
     debugChannel.info('Exec juvix repl');
     let shellCmd = this.config.getJuvixExec();
     if (this.document.languageId == 'Juvix') {
@@ -114,9 +112,10 @@ export class JuvixRepl {
   }
 
   /* Load the current file in the REPL */
-  public loadFileRepl() {
+  public loadFileRepl(): void {
     const filename = this.document.fileName;
     debugChannel.info('Loading file in REPL: ' + filename);
+    if (canRunRepl(this.document)) this.document.save();
     if (this.document.languageId == 'Juvix') {
       if (!this.reloadNextTime) this.terminal.sendText(`:load ${filename}`);
       else this.terminal.sendText(`\n:reload ${filename}`);
@@ -128,40 +127,39 @@ export class JuvixRepl {
     this.show();
   }
 
-  public sendText(msg: string) {
+  public sendText(msg: string): void {
     debugChannel.info('Sending text to REPL: ' + msg);
     this.terminal.sendText(msg);
   }
 
-  public dispose() {
+  public dispose(): void {
     debugChannel.info('Disposing Juvix REPL');
     this.terminal.dispose();
-    for (const disposable of this.disposables) {
-      disposable.dispose();
-    }
+    for (const disposable of this.disposables) disposable.dispose();
   }
-  public clear() {
+  public clear(): void {
     vscode.commands.executeCommand('workbench.action.terminal.clear');
   }
-  public show() {
+  public show(): void {
     this.terminal.show(true);
   }
-  public exitStatus() {
+  public exitStatus(): void {
     this.terminal.exitStatus;
   }
 
-  public notAvailable() {
-    return this.terminal.exitStatus && this.terminal.exitStatus.code !== 0;
+  public notAvailable(): boolean {
+    if (!this.terminal.exitStatus) return false;
+    return this.terminal.exitStatus.code !== 0;
   }
 }
 
 export async function activate(context: vscode.ExtensionContext) {
   /* Create a new terminal and send the command to load the current file */
-
-  const cmdVscode = vscode.commands.registerCommand('juvix-mode.repl', () => {
-    const document = vscode.window.activeTextEditor?.document;
-    if (!document) return;
-    if (document.languageId == 'Juvix' || document.languageId == 'JuvixCore') {
+  const loadFile = vscode.commands.registerCommand(
+    'juvix-mode.loadFileRepl',
+    () => {
+      const document = vscode.window.activeTextEditor?.document;
+      if (!document || !canRunRepl(document)) return;
       let repl = juvixTerminals.get(document.fileName);
       if (!repl || repl.notAvailable()) {
         repl?.dispose();
@@ -170,32 +168,32 @@ export async function activate(context: vscode.ExtensionContext) {
       debugChannel.info('repl: ' + repl.document.fileName);
       repl.loadFileRepl();
     }
-  });
-  context.subscriptions.push(cmdVscode);
+  );
+  context.subscriptions.push(loadFile);
 
   // Create a status bar button to open the REPL
-  // only if the current file is a Juvix file or a JuvixCore file
+  // only visible when a Juvix/JuvixCore file is open
 
   const buttonREPL = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left
   );
-  buttonREPL.command = 'juvix-mode.repl';
-  buttonREPL.text = 'Open Juvix REPL';
+  buttonREPL.command = 'juvix-mode.loadFileRepl';
+  buttonREPL.text = 'Load file in Juvix REPL';
   context.subscriptions.push(buttonREPL);
 
   const doc = vscode.window.activeTextEditor?.document;
-  if (doc && (doc.languageId == 'Juvix' || doc.languageId == 'JuvixCore'))
-    buttonREPL.show();
+  if (doc && canRunRepl(doc)) buttonREPL.show();
 
   const watchButton = vscode.window.onDidChangeActiveTextEditor(editor => {
     if (editor) {
       const doc = editor.document;
-      if (doc.languageId == 'Juvix' || doc.languageId == 'JuvixCore') {
-        buttonREPL.show();
-      } else {
-        buttonREPL.hide();
-      }
+      if (canRunRepl(doc)) buttonREPL.show();
+      else buttonREPL.hide();
     }
   });
   context.subscriptions.push(watchButton);
+}
+
+function canRunRepl(document: vscode.TextDocument): boolean {
+  return document.languageId == 'Juvix' || document.languageId == 'JuvixCore';
 }


### PR DESCRIPTION
This PR adds minor revisions to the REPL and solves an issue triggered by typing '\'.


As it's now, the juvix input method (based on lean's) creates an object of the class AbbreviationFeatureRewrite per document, which replaces words with other words/symbols (using a table provided in the package configuration). So, one rewriter object must be created every time a Juvix file is opened and we should be disposed of it, as soon as the document is closed. Otherwise, the rewriter creates tons of conflicts. Before this PR, I was using a function called autorun from the mobx library for creating/disposing of some objects. It works fine, in some scenarios. However, but this input method issues, it does not. I took the simple vscode/ts approach, which in fact, seems to work as expected.
 