### PR TITLE
Do not use custom shellPath in repl and dev

### DIFF
--- a/src/dev.ts
+++ b/src/dev.ts
@@ -103,7 +103,6 @@ class View {
       name: title,
       cwd: path.dirname(this.doc.fileName),
       isTransient: false,
-      shellPath: '/usr/bin/bash',
       location: {
         viewColumn: vscode.ViewColumn.Beside,
         preserveFocus: true,

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -39,7 +39,6 @@ export class JuvixRepl {
       name: terminalName,
       cwd: path.dirname(document.fileName),
       isTransient: false,
-      shellPath: '/usr/bin/bash',
       location: {
         viewColumn: vscode.ViewColumn.Beside,
         preserveFocus: true,
@@ -181,7 +180,6 @@ export async function activate(context: vscode.ExtensionContext) {
         const tempTerminal = vscode.window.createTerminal({
           name: terminalName,
           isTransient: false,
-          shellPath: '/usr/bin/bash',
           location: {
             viewColumn: vscode.ViewColumn.Beside,
             preserveFocus: true,


### PR DESCRIPTION
* Resolves #47 

Instead of using the custom path to shell, do not specify it, so that the default one (or the one set-up for the user) will be used.

Tested on my Mac machine, Previously, it faild to open repl command. After this change, successfully loads the repl.

Here is the usage of it on the `juvix-stdlib` repo:
<img width="1441" alt="Screenshot 2023-04-11 at 15 20 06" src="https://user-images.githubusercontent.com/8126674/231192682-6053af2c-3d68-426a-ad79-708999c7a7d8.png">
