### PR TITLE
Use juvix format command instead of dev scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,8 +364,8 @@
         "when": "editorLangId == Juvix && editorTextFocus"
       },
       {
-        "command": "juvix-mode.dev-scope",
-        "title": "[dev] scope",
+        "command": "juvix-mode.format",
+        "title": "format",
         "category": "Juvix",
         "when": "editorLangId == Juvix && editorTextFocus"
       },

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -25,11 +25,8 @@ export function activate(_context: vscode.ExtensionContext) {
       const formatterCall = [
         config.getJuvixExec(),
         config.getGlobalFlags(),
-        '--stdin',
-        'dev',
-        'scope',
+        'format',
         filePath,
-        '--with-comments',
       ].join(' ');
 
       debugChannel.appendLine(formatterCall);

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -149,7 +149,7 @@ export class JuvixTaskProvider implements vscode.TaskProvider {
         reveal: vscode.TaskRevealKind.Always,
       },
       {
-        command: 'dev scope',
+        command: 'format',
         args: ['${file}'],
         group: vscode.TaskGroup.Build,
         reveal: vscode.TaskRevealKind.Always,
@@ -210,7 +210,7 @@ export async function JuvixTask(
     case 'run':
       exec = new vscode.ShellExecution(
         JuvixExec +
-          ` compile --output ${buildDir}\${pathSeparator}out ${fl} && ${buildDir}\${pathSeparator}out`,
+        ` compile --output ${buildDir}\${pathSeparator}out ${fl} && ${buildDir}\${pathSeparator}out`,
         { cwd: buildDir }
       );
       break;


### PR DESCRIPTION
* Resolves #52 

In this PR, I solely replace the usage of the `dev scope` with the `format` command, keeping the print of the command in the output as it was previously.

I tested it locally, now the previously `Juvix: [dev] scope` command appears as `Juvix: format` and works as the former one.
My autoformatting continue working too.
Let me know if any other testing or adjustments are required.