### PR TITLE
Add in keyword to JuvixCore list

### DIFF
--- a/syntaxes/JuvixCore.tmLanguage.json
+++ b/syntaxes/JuvixCore.tmLanguage.json
@@ -17,14 +17,16 @@
     {
       "include": "#block-comment"
     },
-    { "include": "#constants" }
+    {
+      "include": "#constants"
+    }
   ],
   "repository": {
     "keywords": {
       "patterns": [
         {
           "name": "keyword.control.JuvixCore",
-          "match": "(\\b(def|match|with|case|of|true|false|inductive|if|then|else|let|letrec|writeLn|constr|write|return|builtin|type)\\b)"
+          "match": "(\\b(def|match|with|case|of|true|false|inductive|if|then|else|let|letrec|in|writeLn|constr|write|return|builtin|type)\\b)"
         },
         {
           "name": "keyword.control.JuvixCore",

--- a/test/test.jvc
+++ b/test/test.jvc
@@ -2,4 +2,8 @@ def sum := \x if x = 0 then 0 else x + sum (x - 1);
 
 sum 10000
 
+let x := 5 in
+let y := 10 in
+x + y;
+
 {- DEBUG: CoreRead -}


### PR DESCRIPTION
* Resolves #49 

See the test file. Now the `let-in` constructions are highlighted:

<img width="127" alt="Screenshot 2023-04-13 at 10 33 14" src="https://user-images.githubusercontent.com/8126674/231718327-9085fdc9-b8da-4fa2-a6f0-8ac40fb21a28.png">
