### PR TITLE
remove juvix:format command in favor of using the built-in vsce api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2256,20 +2256,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -413,12 +413,6 @@
         "when": "editorLangId == Juvix && editorTextFocus"
       },
       {
-        "command": "juvix-mode.format",
-        "title": "format",
-        "category": "Juvix",
-        "when": "editorLangId == Juvix && editorTextFocus"
-      },
-      {
         "command": "juvix-mode.core-eval",
         "title": "[dev] core-eval",
         "category": "Juvix",
@@ -2636,8 +2630,6 @@
             "CatFile": "cat $filename",
             "Parsed": "$juvix dev parse $filename",
             "Scoped": "$juvix dev scope $filename",
-            "HighlightJSON": "$juvix dev highlight --format json $filename",
-            "Highlight": "$juvix dev highlight $filename",
             "InternalPretty": "$juvix dev internal pretty $filename",
             "InternalArity": "$juvix dev internal arity $filename",
             "InternalTypecheck": "$juvix dev internal typecheck $filename",

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -66,20 +66,6 @@ export interface JuvixTaskDefinition extends vscode.TaskDefinition {
 export class JuvixTaskProvider implements vscode.TaskProvider {
   async provideTasks(): Promise<vscode.Task[]> {
     const config = new user.JuvixConfig();
-    const setupPanel = () => {
-      let panelOpt: vscode.TaskRevealKind;
-      switch (config.revealPanel.get()) {
-        case 'always':
-          panelOpt = vscode.TaskRevealKind.Always;
-          break;
-        case 'never':
-          panelOpt = vscode.TaskRevealKind.Never;
-          break;
-        default:
-          panelOpt = vscode.TaskRevealKind.Silent;
-      }
-      return panelOpt;
-    };
 
     const defs = [
       {
@@ -148,12 +134,6 @@ export class JuvixTaskProvider implements vscode.TaskProvider {
         group: vscode.TaskGroup.Build,
         reveal: vscode.TaskRevealKind.Always,
       },
-      {
-        command: 'format',
-        args: ['${file}'],
-        group: vscode.TaskGroup.Build,
-        reveal: vscode.TaskRevealKind.Always,
-      },
     ];
 
     const tasks: vscode.Task[] = [];
@@ -210,7 +190,7 @@ export async function JuvixTask(
     case 'run':
       exec = new vscode.ShellExecution(
         JuvixExec +
-        ` compile --output ${buildDir}\${pathSeparator}out ${fl} && ${buildDir}\${pathSeparator}out`,
+          ` compile --output ${buildDir}\${pathSeparator}out ${fl} && ${buildDir}\${pathSeparator}out`,
         { cwd: buildDir }
       );
       break;

--- a/test/HelloWorld.juvix
+++ b/test/HelloWorld.juvix
@@ -1,1 +1,6 @@
-module HelloWorld; open import Stdlib.Prelude; main : IO; main := printStringLn "hello world!"; end;
+module HelloWorld;
+
+open import Stdlib.Prelude;
+
+main : IO;
+main := printStringLn "hello world!";


### PR DESCRIPTION
This PR removes the need for a separate command for formatting, as we have `formatter.ts` which
register a formatting provider using the VSCode extension API.
So, use the command palette to call the formatted next time. 