### PR TITLE
Fix tmp .juvix-build creation in run command

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -83,15 +83,15 @@ export class JuvixConfig {
       const juvixBuildDir = buildDir.toString();
       try {
         if (fs.existsSync(juvixBuildDir)) {
-          console.log("Directory exists.", juvixBuildDir)
+          debugChannel.info(`Directory exists: ${juvixBuildDir}`);
           return juvixBuildDir;
         } else {
-          console.log("Directory does not exist.", juvixBuildDir)
+          debugChannel.info(`Directory does not exist: ${juvixBuildDir}`);
           const tmpJuvixDir = useTmpDir();
           return tmpJuvixDir
         }
       } catch (e) {
-        console.log("An error occurred.", e)
+        debugChannel.error(`An error occurred: ${e}`);
         const tmpJuvixBuildDir = useTmpDir();
         return tmpJuvixBuildDir;
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,8 +10,6 @@ import * as path from 'path';
 import { tmpdir } from 'os';
 import { debugChannel } from './utils/debug';
 
-// let juvixBuildDir: string | undefined;
-
 export class JuvixConfig {
   readonly binaryName = new VsCodeSetting('juvix-mode.bin.name', {
     serializer: serializerWithDefault('Juvix'),
@@ -68,14 +66,14 @@ export class JuvixConfig {
   public getInternalBuildDir(): string | undefined {
 
     const useTmpDir = () => {
-      const tmp = fs.mkdtempSync(path.join(tmpdir(), '.juvix-build'));
+      const tmpPath = path.join(tmpdir(), '.juvix-build');
       try {
-        const tmp = fs.mkdtempSync(path.join(tmpdir(), '.juvix-build'));
+        const tmp = fs.mkdtempSync(tmpPath);
         const juvixBuildDir = tmp.toString();
         console.log("TMP dir", juvixBuildDir);
         return juvixBuildDir;
       } catch (e) {
-        debugChannel.error('Error creating temporary directory: ' + e);
+        debugChannel.error(`Error creating temporary directory ${tmpPath}: ${e}`);
       }
     }
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -190,7 +190,7 @@ export async function JuvixTask(
     case 'run':
       exec = new vscode.ShellExecution(
         JuvixExec +
-          ` compile --output ${buildDir}\${pathSeparator}out ${fl} && ${buildDir}\${pathSeparator}out`,
+        ` compile --output ${buildDir}\${pathSeparator}out ${fl} && ${buildDir}\${pathSeparator}out`,
         { cwd: buildDir }
       );
       break;


### PR DESCRIPTION
After debugging, I found out that the problem was in the lack of permissions in a way we were creating tmp `.juvix-build` folder. 

With this change, it is fixed and currently it is working for me even when the `.juvix-build` folder doesn't exist.

* Resolves #54 