### PR TITLE
Allow multi-line error highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,12 +329,13 @@
         "pattern": [
           {
             "kind": "location",
-            "regexp": "^(.+):(\\d+):(\\d+)-(\\d+): (\\w+).*",
+            "regexp": "^(.+):(\\d+)(?:-(\\d+))?:(\\d+)-(\\d+): (\\w+).*",
             "file": 1,
             "line": 2,
-            "column": 3,
-            "endColumn": 4,
-            "severity": 5
+            "endLine": 3,
+            "column": 4,
+            "endColumn": 5,
+            "severity": 6
           },
           {
             "regexp": "(.*)",


### PR DESCRIPTION
Resolves the problem with errors highlighting for the multi-line errors.

It was describes in the example of this issue: #60 

I am not sure if this is everything that was meant under the specs of the issue. @lukaszcz could you confirm that this solves the issue that you describe?

Specifically, currently this is the highlighted result of the compiling `Compilation/negative/test002.juvix`

<img width="207" alt="Screenshot 2023-04-14 at 15 58 58" src="https://user-images.githubusercontent.com/8126674/232080251-890eb740-5f9a-42ec-9821-caeb2eb37285.png">
