### PR TITLE
Add html only sources task

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
         "title": "Html preview [only source]",
         "category": "Juvix",
         "when": "editorLangId == Juvix && editorTextFocus",
-        "icon": "$(book)"
+        "icon": "$(file-code)"
       },
       {
         "command": "juvix-mode.dev-parse",

--- a/package.json
+++ b/package.json
@@ -408,6 +408,13 @@
         "icon": "$(book)"
       },
       {
+        "command": "juvix-mode.createOrShowJudocOnlySource",
+        "title": "Html preview [only source]",
+        "category": "Juvix",
+        "when": "editorLangId == Juvix && editorTextFocus",
+        "icon": "$(book)"
+      },
+      {
         "command": "juvix-mode.dev-parse",
         "title": "[dev] parse",
         "category": "Juvix",
@@ -619,6 +626,11 @@
           "when": "editorLangId == Juvix",
           "command": "juvix-mode.createOrShowJudoc",
           "group": "navigation@4"
+        },
+        {
+          "when": "editorLangId == Juvix",
+          "command": "juvix-mode.createOrShowJudocOnlySource",
+          "group": "navigation@5"
         }
       ],
       "editor/context": [

--- a/src/judoc.ts
+++ b/src/judoc.ts
@@ -17,7 +17,14 @@ export function activate(context: vscode.ExtensionContext) {
       }
     )
   );
-
+  context.subscriptions.push(
+    vscode.commands.registerTextEditorCommand(
+      'juvix-mode.createOrShowJudocOnlySource',
+      () => {
+        JudocPanel.createOrShow(true);
+      }
+    )
+  );
   // vscode.languages.registerHoverProvider(
   //   'javascript',
   //   new (class implements vscode.HoverProvider {
@@ -69,6 +76,7 @@ function getWebviewOptions(): vscode.WebviewOptions {
 export class JudocPanel {
   public static currentPanel: JudocPanel | undefined;
   public static juvixDocument: vscode.TextDocument;
+  public static onlySource: boolean;
 
   public static readonly viewType = 'juvix-mode';
   public readonly assetsPath = 'assets';
@@ -77,7 +85,8 @@ export class JudocPanel {
   private _disposables: vscode.Disposable[] = [];
   // public  readonly htmlFolder : string;
 
-  public static createOrShow() {
+  public static createOrShow(onlySource = false) {
+    this.onlySource = onlySource;
     const editor = vscode.window.activeTextEditor;
     if (!editor || !isJuvixFile(editor.document)) return;
     this.juvixDocument = editor.document;
@@ -234,6 +243,7 @@ export class JudocPanel {
       '--internal-build-dir',
       judocDocFolderUri.fsPath,
       'html',
+      JudocPanel.onlySource ? '--only-source' : '',
       '--output-dir',
       // this.htmlFolder,
       judocDocFolderUri.fsPath,


### PR DESCRIPTION
* Resolves #38 

Now there are two separate command: HTML and HTML [only source]
This is the output of the only sources command:

<img width="1236" alt="Screenshot 2023-05-02 at 08 59 44" src="https://user-images.githubusercontent.com/8126674/235611629-2f2de58e-6cac-43f5-8c81-ef4fba0fa426.png">
