### PR TITLE
Handle unicode character in semantic highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
             "function": {
               "foreground": "#d98200"
             },
-            "inductive": {
+            "type": {
               "foreground": "#769c03"
             },
             "keyword": {
@@ -185,7 +185,7 @@
             "function": {
               "foreground": "#feb64a"
             },
-            "inductive": {
+            "type": {
               "foreground": "#86b300"
             },
             "keyword": {

--- a/src/highlighting.ts
+++ b/src/highlighting.ts
@@ -175,8 +175,21 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
               ? tk.interval.length
               : tk.interval.endCol
             : contentLines[l].length;
+        // lineLength represent the number of symbols we can see on the screen.
+        // However, in js, length for unicode symbols works not as expected, but
+        // rather shows the code units number.
+        // So we need to actually calculate all the code units.
+        // In case of the unicode symbol, we need to take 2 positions instead of one.
+        let realLength = 0;
+        for (let i = startCol; i < startCol + lineLength; i++) {
+          if (contentLines[l].charCodeAt(i) > 255) {
+            realLength += 2;
+          } else {
+            realLength += 1;
+          }
+        }
 
-        builder.push(l, startCol, lineLength, token, 0);
+        builder.push(l, startCol, realLength, token, 0);
       }
     });
     return builder.build();

--- a/src/highlighting.ts
+++ b/src/highlighting.ts
@@ -48,7 +48,7 @@ export const legend: vscode.SemanticTokensLegend = (function () {
     'constructor',
     'error',
     'function',
-    'inductive',
+    'type',
     'keyword',
     'module',
     'number',


### PR DESCRIPTION
- Resolves #72 

I needed to handle unicode symbols in a special way as `length` property is not actually what the token length expects

<img width="326" alt="Screenshot 2023-05-11 at 08 43 51" src="https://github.com/anoma/vscode-juvix/assets/8126674/d322478d-1ef2-4085-9e02-4c629879e664">
