### PR TITLE
Handle judoc as comments in highlighting

### DIFF
--- a/src/highlighting.ts
+++ b/src/highlighting.ts
@@ -34,7 +34,6 @@ export async function activate(context: vscode.ExtensionContext) {
       })
     );
     debugChannel.debug('Semantic syntax highlighter registered');
-
   } catch (error) {
     debugChannel.error('No semantic provider', error);
   }
@@ -251,6 +250,8 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
   private encodeTokenType(tokenType: string): number {
     if (tokenTypes.has(tokenType)) {
       return tokenTypes.get(tokenType)!;
+    } else if (tokenType === 'judoc') {
+      return tokenTypes.get('comment')!;
     } else if (tokenType === 'notInLegend') {
       return tokenTypes.size + 2;
     }


### PR DESCRIPTION
Resolves #76 

Now it highlights the judoc comments as simple comments:

![Screenshot 2023-05-15 at 21 52 14](https://github.com/anoma/vscode-juvix/assets/8126674/3046726c-e295-4f9b-bc1a-1b1fca0910d1)
