### PR TITLE
Use the typecheckOn var from settings for deciding to typecheck

### DIFF
--- a/test/Format.juvix
+++ b/test/Format.juvix
@@ -10,7 +10,7 @@ go n s :=
     (go (sub n 1) s)
     (go n (sub s n) + go (sub n 1) s);
 
-module M; infixr 4 ,; axiom , : String → String → String; end;
+modul; axiom , : String → String → String; end;
 
 -- qualified commas
 t4 : String;


### PR DESCRIPTION
This PR returns back the check on the settings variable `typecheckOn` check in order to decide to typecheck on save/change or not to typecheck. By default it is set to `none`, so with the default settings, the highlighting should work faster now, and will not slow down the project.

Further investigations on why the `typecheck-silent` command is so resourse consuming needs to be done, but for now it makes the extension usable.

Btw, highlighting now works extremely great and it doesn't disappear with the errors 🚀 