### PR TITLE
Fix README, remove shortcut for loading the repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ properly.
 | typecheck | <kbd>Shift+Alt+T</kbd> |
 | compile   | <kbd>Shift+Alt+C</kbd> |
 | run       | <kbd>Shift+Alt+X</kbd> |
-| repl      | <kbd>Shift+Alt+E</kbd> |
 | doctor    | <kbd>Shift+Alt+D</kbd> |
 
 However, we recommend using the Command Palette (<kbd>Ctrl</kbd><kbd>P</kbd>) to


### PR DESCRIPTION
This PR 
- closes #42 

There is no shortcut for loading the REPL. To access the REPL, 
the user can either:

- Click the button "Load file.." in the status bar,
- click the icon button in the tab bar, or
- execute the "Juvix Load REPL" from the command palette (common use in VSCode)