### PR TITLE
Codebase maintenance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         exclude: assets/
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v3.0.0-alpha.6' # Use the sha or tag you want to point at
+    rev: 'v3.0.0-alpha.9-for-vscode' # Use the sha or tag you want to point at
     hooks:
       - id: prettier
         types_or: [css, javascript, markdown, yaml, toml]

--- a/package.json
+++ b/package.json
@@ -555,13 +555,13 @@
         "command": "juvix-mode.enableCodeLens",
         "title": "Enable CodeLens",
         "category": "Juvix",
-         "when": "editorLangId == juvix && editorTextFocus"
+        "when": "editorLangId == juvix && editorTextFocus"
       },
-            {
+      {
         "command": "juvix-mode.disableCodeLens",
         "title": "Disable CodeLens",
         "category": "Juvix",
-         "when": "editorLangId == juvix && editorTextFocus"
+        "when": "editorLangId == juvix && editorTextFocus"
       }
     ],
     "submenus": [

--- a/snippets/Juvix.json
+++ b/snippets/Juvix.json
@@ -1,67 +1,41 @@
 {
   "module": {
-    "prefix": [
-      "mod",
-      "module"
-    ],
+    "prefix": ["mod", "module"],
     "body": "module ${1:moduleName};\n  ${2:moduleBody}\n",
     "description": "module type"
   },
   "data types": {
-    "prefix": [
-      "type",
-      "inductive",
-      "data"
-    ],
+    "prefix": ["type", "inductive", "data"],
     "body": "type ${1:typeName} := \n  | ${3:constructorName} : ${4:constructorArgs} -> ${5:returnType}\n  | ${6:constructorName} : ${7:constructorArgs} -> ${8:returnType};\n",
     "description": "inductive data type declaration"
   },
   "axiom": {
-    "prefix": [
-      "axiom",
-      "postulate",
-      "definition"
-    ],
+    "prefix": ["axiom", "postulate", "definition"],
     "body": "\naxiom ${1:axiomName} : ${2:axiomType};\n",
     "description": "Axiom"
   },
   "function": {
-    "prefix": [
-      "function"
-    ],
+    "prefix": ["function"],
     "body": "${1:functionName} : ${2:functionType};\n$1 := ${3:functionBody};\n",
     "description": "Axiom"
   },
   "comment": {
-    "prefix": [
-      "comment",
-      "--"
-    ],
+    "prefix": ["comment", "--"],
     "body": "-- ${1:commentBody}\n",
     "description": "comment inline"
   },
   "comment block": {
-    "prefix": [
-      "comment",
-      "--",
-      "{-"
-    ],
+    "prefix": ["comment", "--", "{-"],
     "body": "{-\n  ${1:commentBody}\n-}",
     "description": "comment block"
   },
   "judoc inline": {
-    "prefix": [
-      "judoc",
-      "---"
-    ],
+    "prefix": ["judoc", "---"],
     "body": "--- ${1:judoc inline}",
     "description": "Judoc inline documentation"
   },
   "judoc block": {
-    "prefix": [
-      "judoc",
-      "{--"
-    ],
+    "prefix": ["judoc", "{--"],
     "body": "{--\n  ${1:Judoc documenation}\n--}",
     "description": "Judoc documenation"
   }

--- a/src/abbreviation/rewriter/AbbreviationRewriterFeature.ts
+++ b/src/abbreviation/rewriter/AbbreviationRewriterFeature.ts
@@ -4,7 +4,7 @@
 import { observable } from 'mobx';
 import { Disposable, languages, TextEditor, window } from 'vscode';
 import { autorunDisposable } from '../../utils/autorunDisposable';
-import { debugChannel } from '../../utils/debug';
+import { logger } from '../../utils/debug';
 import { AbbreviationProvider } from '../AbbreviationProvider';
 import { AbbreviationConfig } from '../config';
 import { AbbreviationRewriter } from './AbbreviationRewriter';
@@ -42,7 +42,7 @@ export class AbbreviationRewriterFeature {
               config,
               abbreviationProvider,
               this.activeTextEditor,
-              debugChannel
+              logger.outputChannel
             )
           );
         }

--- a/src/check.ts
+++ b/src/check.ts
@@ -38,7 +38,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
         if (ls.status !== 0) {
           const errMsg: string = "Juvix's Error: " + ls.stderr.toString();
-          logger.error('typechecking-silent provider error' + errMsg , 'check.ts');
+          logger.error(
+            'typechecking-silent provider error' + errMsg,
+            'check.ts'
+          );
           throw new Error(errMsg);
         }
         return ls.stdout;

--- a/src/check.ts
+++ b/src/check.ts
@@ -5,7 +5,7 @@
 import * as vscode from 'vscode';
 import * as user from './config';
 import { isJuvixFile } from './utils/base';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 import { spawnSync } from 'child_process';
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -22,18 +22,13 @@ export async function activate(context: vscode.ExtensionContext) {
     if (activeEditor && activeEditor.document == doc) {
       if (doc && isJuvixFile(doc)) {
         const filePath = doc.fileName;
-        debugChannel.info(`Checking... ${filePath}!`);
         const typecheckerCall = [
           config.getJuvixExec(),
           config.getGlobalFlags(),
           '--only-errors',
           'typecheck',
           filePath,
-          // '--stdin',
-          // content,
         ].join(' ');
-
-        debugChannel.info('Typecheker call: ' + typecheckerCall);
 
         const ls = spawnSync(typecheckerCall, {
           input: content,
@@ -43,10 +38,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
         if (ls.status !== 0) {
           const errMsg: string = "Juvix's Error: " + ls.stderr.toString();
-          debugChannel.error('typechecking-silent provider error', errMsg);
+          logger.error('typechecking-silent provider error' + errMsg , 'check.ts');
           throw new Error(errMsg);
         }
-        const stdout = ls.stdout;
+        return ls.stdout;
       }
     }
   };

--- a/src/codelens.ts
+++ b/src/codelens.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as statusbar from './statusbar';
 import { getModuleName } from './module';
+import { logger } from './utils/debug';
+import { isJuvixFile } from './utils/base';
 
 /**
  * CodelensProvider
@@ -54,8 +56,13 @@ export class CodelensProvider implements vscode.CodeLensProvider {
         , _token: vscode.CancellationToken)
         : vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
 
+        if (!isJuvixFile(document)) {
+        return [];
+        }
+
         if (vscode.workspace.getConfiguration("juvix-mode").get("codeLens", true)) {
             this.codeLenses = [];
+
             const text = document.getText();
             let firstLineRange = document.lineAt(0).range;
             /*

--- a/src/codelens.ts
+++ b/src/codelens.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import * as statusbar from './statusbar';
 import { getModuleName } from './module';
-import { logger } from './utils/debug';
 import { isJuvixFile } from './utils/base';
 
 /**

--- a/src/codelens.ts
+++ b/src/codelens.ts
@@ -8,73 +8,80 @@ import { isJuvixFile } from './utils/base';
  */
 
 export function activate(context: vscode.ExtensionContext) {
-    context.subscriptions.push(
-        vscode.languages.registerCodeLensProvider(
-            { scheme: 'file', language: 'Juvix' },
-            new CodelensProvider()
-        )
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand("juvix-mode.enableCodeLens", () => {
-            vscode.workspace.getConfiguration("juvix-mode").update("enableCodeLens", true, true);
-        })
-    );
-    context.subscriptions.push(
-        vscode.commands.registerCommand("juvix-mode.disableCodeLens", () => {
-            vscode.workspace.getConfiguration("juvix-mode").update("enableCodeLens", false, true);
-        })
-    );
+  context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider(
+      { scheme: 'file', language: 'Juvix' },
+      new CodelensProvider()
+    )
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('juvix-mode.enableCodeLens', () => {
+      vscode.workspace
+        .getConfiguration('juvix-mode')
+        .update('enableCodeLens', true, true);
+    })
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('juvix-mode.disableCodeLens', () => {
+      vscode.workspace
+        .getConfiguration('juvix-mode')
+        .update('enableCodeLens', false, true);
+    })
+  );
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("juvix-mode.aux.prependText", (args: any) => {
-            const editor = vscode.window.activeTextEditor;
-            if (editor) {
-                const position = new vscode.Position(0, 0);
-                editor.edit((editBuilder) => {
-                    editBuilder.insert(position, args.text);
-                });
-            }
-        })
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'juvix-mode.aux.prependText',
+      (args: any) => {
+        const editor = vscode.window.activeTextEditor;
+        if (editor) {
+          const position = new vscode.Position(0, 0);
+          editor.edit(editBuilder => {
+            editBuilder.insert(position, args.text);
+          });
+        }
+      }
+    )
+  );
 }
 
 export class CodelensProvider implements vscode.CodeLensProvider {
+  private codeLenses: vscode.CodeLens[] = [];
+  private _onDidChangeCodeLenses: vscode.EventEmitter<void> =
+    new vscode.EventEmitter<void>();
+  public readonly onDidChangeCodeLenses: vscode.Event<void> =
+    this._onDidChangeCodeLenses.event;
 
-    private codeLenses: vscode.CodeLens[] = [];
-    private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
-    public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+  constructor() {
+    vscode.workspace.onDidChangeConfiguration(_ => {
+      this._onDidChangeCodeLenses.fire();
+    });
+  }
 
-    constructor() {
-        vscode.workspace.onDidChangeConfiguration((_) => {
-            this._onDidChangeCodeLenses.fire();
-        });
+  public provideCodeLenses(
+    document: vscode.TextDocument,
+    _token: vscode.CancellationToken
+  ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+    if (!isJuvixFile(document)) {
+      return [];
     }
 
-    public provideCodeLenses(
-        document: vscode.TextDocument
-        , _token: vscode.CancellationToken)
-        : vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+    if (vscode.workspace.getConfiguration('juvix-mode').get('codeLens', true)) {
+      this.codeLenses = [];
 
-        if (!isJuvixFile(document)) {
-        return [];
-        }
-
-        if (vscode.workspace.getConfiguration("juvix-mode").get("codeLens", true)) {
-            this.codeLenses = [];
-
-            const text = document.getText();
-            let firstLineRange = document.lineAt(0).range;
-            /*
+      const text = document.getText();
+      let firstLineRange = document.lineAt(0).range;
+      /*
             Add a code lenses to show the Juvix version
             in the first line of the document.
             */
-            let juvixVersionCodeLenses = new vscode.CodeLens(firstLineRange, {
-                title: "Powered by " + statusbar.juvixStatusBarItemVersion.text,
-                command: ""
-            });
-            this.codeLenses.push(juvixVersionCodeLenses);
+      let juvixVersionCodeLenses = new vscode.CodeLens(firstLineRange, {
+        title: 'Powered by ' + statusbar.juvixStatusBarItemVersion.text,
+        command: '',
+      });
+      this.codeLenses.push(juvixVersionCodeLenses);
 
-            /*
+      /*
             Add a code lenses that checks if the document is empty.
             If it is, it suggests to insert the module header
             relative to juvixRoot.
@@ -84,29 +91,32 @@ export class CodelensProvider implements vscode.CodeLensProvider {
             and the slashes are replaced by dots.
             */
 
-            let regex = /module\s+([\w.]+);/;
-            let match = text.match(regex);
-            let moduleName: string | undefined = getModuleName(document);
-            if (moduleName && (text.length === 0 || match === null)) {
-                let moduleTopHeader: string = `module ${moduleName};`;
-                let insertModuleCodeLenses = new vscode.CodeLens(
-                    new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)),
-                    {
-                        title: `Insert "${moduleTopHeader}"`,
-                        command: "juvix-mode.aux.prependText",
-                        arguments: [
-                            {
-                                text: `${moduleTopHeader}\n\n`
-                            }
-                        ]
-                    }
-                );
+      let regex = /module\s+([\w.]+);/;
+      let match = text.match(regex);
+      let moduleName: string | undefined = getModuleName(document);
+      if (moduleName && (text.length === 0 || match === null)) {
+        let moduleTopHeader: string = `module ${moduleName};`;
+        let insertModuleCodeLenses = new vscode.CodeLens(
+          new vscode.Range(
+            new vscode.Position(0, 0),
+            new vscode.Position(0, 0)
+          ),
+          {
+            title: `Insert "${moduleTopHeader}"`,
+            command: 'juvix-mode.aux.prependText',
+            arguments: [
+              {
+                text: `${moduleTopHeader}\n\n`,
+              },
+            ],
+          }
+        );
 
-                this.codeLenses = [insertModuleCodeLenses].concat(this.codeLenses);
-            }
+        this.codeLenses = [insertModuleCodeLenses].concat(this.codeLenses);
+      }
 
-            return this.codeLenses;
-        }
-        return [];
+      return this.codeLenses;
     }
+    return [];
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,6 @@ export class JuvixConfig {
   readonly judocDir = new VsCodeSetting('juvix-mode.opts.judocDir');
 
   public getInternalBuildDir(): string | undefined {
-
     const useTmpDir = () => {
       const tmpPath = path.join(tmpdir(), '.juvix-build');
       try {
@@ -72,9 +71,12 @@ export class JuvixConfig {
         const juvixBuildDir = tmp.toString();
         return juvixBuildDir;
       } catch (e) {
-        logger.error(`Error creating temporary directory ${tmpPath}: ${e}`, 'config.ts');
+        logger.error(
+          `Error creating temporary directory ${tmpPath}: ${e}`,
+          'config.ts'
+        );
       }
-    }
+    };
 
     const buildDir = this.internalBuildDir.get();
 
@@ -85,14 +87,13 @@ export class JuvixConfig {
           return juvixBuildDir;
         } else {
           const tmpJuvixDir = useTmpDir();
-          return tmpJuvixDir
+          return tmpJuvixDir;
         }
       } catch (e) {
         logger.error(`An error occurred: ${e}`, 'config.ts');
         const tmpJuvixBuildDir = useTmpDir();
         return tmpJuvixBuildDir;
       }
-
     }
     const tmpJuvixBuildDir = useTmpDir();
     return tmpJuvixBuildDir;
@@ -106,7 +107,10 @@ export class JuvixConfig {
       fs.mkdirSync(tmp);
       return tmp.toString();
     } catch (e) {
-      logger.error('Error creating temporary directory for Judoc: ' + e, 'config.ts');
+      logger.error(
+        'Error creating temporary directory for Judoc: ' + e,
+        'config.ts'
+      );
     }
     return 'html';
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import { serializerWithDefault, VsCodeSetting } from './utils/VsCodeSetting';
 import * as fs from 'fs';
 import * as path from 'path';
 import { tmpdir } from 'os';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 
 export class JuvixConfig {
   readonly binaryName = new VsCodeSetting('juvix-mode.bin.name', {
@@ -70,10 +70,9 @@ export class JuvixConfig {
       try {
         const tmp = fs.mkdtempSync(tmpPath);
         const juvixBuildDir = tmp.toString();
-        console.log("TMP dir", juvixBuildDir);
         return juvixBuildDir;
       } catch (e) {
-        debugChannel.error(`Error creating temporary directory ${tmpPath}: ${e}`);
+        logger.error(`Error creating temporary directory ${tmpPath}: ${e}`, 'config.ts');
       }
     }
 
@@ -89,7 +88,7 @@ export class JuvixConfig {
           return tmpJuvixDir
         }
       } catch (e) {
-        debugChannel.error(`An error occurred: ${e}`);
+        logger.error(`An error occurred: ${e}`, 'config.ts');
         const tmpJuvixBuildDir = useTmpDir();
         return tmpJuvixBuildDir;
       }
@@ -107,7 +106,7 @@ export class JuvixConfig {
       fs.mkdirSync(tmp);
       return tmp.toString();
     } catch (e) {
-      debugChannel.error('Error creating temporary directory for Judoc: ' + e);
+      logger.error('Error creating temporary directory for Judoc: ' + e, 'config.ts');
     }
     return 'html';
   }
@@ -218,3 +217,5 @@ export class JuvixConfig {
 export interface TaggedList {
   [abbrev: string]: string;
 }
+
+export let config = new JuvixConfig();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,14 +4,14 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 import { GotoProperty } from './interfaces';
+import { isJuvixFile } from './utils/base';
 
 export let definitionProvider: vscode.DefinitionProvider;
 export let locationMap = new Map<string, Map<number, GotoProperty[]>>();
 
 export async function activate(context: vscode.ExtensionContext) {
-  /* Go to definition  */
   try {
     definitionProvider = new JuvixDefinitionProvider();
     context.subscriptions.push(
@@ -20,9 +20,8 @@ export async function activate(context: vscode.ExtensionContext) {
         definitionProvider
       )
     );
-    debugChannel.info('Go to definition registered');
   } catch (error) {
-    debugChannel.error('No definition provider', error);
+    logger.error('No definition provider:' + error, 'definitions.ts');
   }
 }
 
@@ -31,63 +30,33 @@ export class JuvixDefinitionProvider implements vscode.DefinitionProvider {
     document: vscode.TextDocument,
     position: vscode.Position
   ): Promise<vscode.Location | vscode.Location[] | undefined> {
-    const filePath: string = document.fileName;
-    const line: number = position.line;
-    const col: number = position.character;
-    debugChannel.info('Go to definition requested ------------------------');
-    debugChannel.info(
-      'info',
-      'Looking for definition of the symbol at: ' + (line + 1) + ':' + (col + 1)
-    );
-    debugChannel.info('Active file: ' + filePath);
+    if (!isJuvixFile(document)) return undefined;
+    const filePath = document.fileName;
+    const line = position.line;
+    const col = position.character;
+
+
     const definitionInfo = locationMap.get(filePath);
     if (!definitionInfo) {
-      debugChannel.info(
-        'There is no definitions registered in file: ' + filePath
-      );
+      logger.warn(`There is no definitions registered in file: ${filePath}`, 'definitions.ts');
       return undefined;
     }
+
     const definitionsByLine = definitionInfo.get(line);
     if (!definitionsByLine) {
-      debugChannel.info(
-        'There is no definitions registered in line: ' + (line + 1)
-      );
+      logger.warn(`There is no definitions registered in line: ${line + 1}`, 'definitions.ts');
       return undefined;
     }
 
-    const locsByLine: GotoProperty[] = definitionsByLine;
-    debugChannel.info(
-      '> Found ' + locsByLine.length + ' definitions at line: ' + (line + 1)
-    );
-    for (let i = 0; i < locsByLine.length; i++) {
-      const info: GotoProperty = locsByLine[i];
-      debugChannel.info(
-        '>> Checking if symbol is between colummns: ' +
-        (info.interval.start + 1) +
-        ' and ' +
-        (info.interval.end + 1)
-      );
-
+    for (const info of definitionsByLine)
       if (info.interval.start <= col && info.interval.end >= col) {
-        debugChannel.info('info', '[!] Found definition at: ' +
-          info.targetFile + ':' + (info.targetLine + 1) + ':'
-          + (info.targetStartCharacter + 1));
-        const rangeBegin = new vscode.Position(
-          info.targetLine,
-          info.targetStartCharacter
-        );
+        const { targetLine, targetStartCharacter, targetFile } = info;
+        const rangeBegin = new vscode.Position(targetLine, targetStartCharacter);
         const lengthIdentifier = info.interval.end - info.interval.start + 1;
-        const rangeEnd = new vscode.Position(
-          info.targetLine,
-          info.targetStartCharacter + lengthIdentifier
-        );
+        const rangeEnd = new vscode.Position(targetLine, targetStartCharacter + lengthIdentifier);
         const positionRange = new vscode.Range(rangeBegin, rangeEnd);
-        const definitionFound = new vscode.Location(
-          vscode.Uri.file(info.targetFile),
-          positionRange
-        );
+        const definitionFound = new vscode.Location(vscode.Uri.file(targetFile), positionRange);
         return definitionFound;
       }
-    }
   }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -48,11 +48,20 @@ export class JuvixDefinitionProvider implements vscode.DefinitionProvider {
     for (const info of definitionsByLine)
       if (info.interval.start <= col && info.interval.end >= col) {
         const { targetLine, targetStartCharacter, targetFile } = info;
-        const rangeBegin = new vscode.Position(targetLine, targetStartCharacter);
+        const rangeBegin = new vscode.Position(
+          targetLine,
+          targetStartCharacter
+        );
         const lengthIdentifier = info.interval.end - info.interval.start + 1;
-        const rangeEnd = new vscode.Position(targetLine, targetStartCharacter + lengthIdentifier);
+        const rangeEnd = new vscode.Position(
+          targetLine,
+          targetStartCharacter + lengthIdentifier
+        );
         const positionRange = new vscode.Range(rangeBegin, rangeEnd);
-        const definitionFound = new vscode.Location(vscode.Uri.file(targetFile), positionRange);
+        const definitionFound = new vscode.Location(
+          vscode.Uri.file(targetFile),
+          positionRange
+        );
         return definitionFound;
       }
   }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -35,16 +35,13 @@ export class JuvixDefinitionProvider implements vscode.DefinitionProvider {
     const line = position.line;
     const col = position.character;
 
-
     const definitionInfo = locationMap.get(filePath);
     if (!definitionInfo) {
-      logger.warn(`There is no definitions registered in file: ${filePath}`, 'definitions.ts');
       return undefined;
     }
 
     const definitionsByLine = definitionInfo.get(line);
     if (!definitionsByLine) {
-      logger.warn(`There is no definitions registered in line: ${line + 1}`, 'definitions.ts');
       return undefined;
     }
 

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -2,7 +2,6 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { logger } from './utils/debug';
 import { JuvixConfig } from './config';
 import * as vscode from 'vscode';
 import { observable } from 'mobx';
@@ -11,7 +10,6 @@ import * as path from 'path';
 const debugStr = 'DEBUG:';
 
 export function activate(context: vscode.ExtensionContext) {
-  logger.trace('Enabling dev tabs');
   const devEnv = new DevEnv();
   context.subscriptions.push(devEnv);
 

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 import { JuvixConfig } from './config';
 import * as vscode from 'vscode';
 import { observable } from 'mobx';
@@ -11,7 +11,7 @@ import * as path from 'path';
 const debugStr = 'DEBUG:';
 
 export function activate(context: vscode.ExtensionContext) {
-  debugChannel.info('Enabling dev tabs');
+  logger.trace('Enabling dev tabs');
   const devEnv = new DevEnv();
   context.subscriptions.push(devEnv);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,19 +4,19 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import * as tasks from './tasks';
-import * as statusBar from './statusbar';
-import * as syntaxHighlighter from './highlighting';
+import * as check from './check';
+import * as codelens from './codelens';
 import * as goToDefinition from './definitions';
+import * as dev from './dev';
+import * as formatter from './formatter';
+import * as syntaxHighlighter from './highlighting';
 import * as hoverInfo from './hover';
 import * as inputMethod from './input';
-import * as repl from './repl';
 import * as judoc from './judoc';
-import * as dev from './dev';
-import * as check from './check';
-import * as formatter from './formatter';
+import * as repl from './repl';
+import * as statusBar from './statusbar';
+import * as tasks from './tasks';
 import * as vampir from './vampir/tasks';
-import * as codelens from './codelens';
 
 export async function activate(context: vscode.ExtensionContext) {
   statusBar.activate(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { logger } from './utils/debug';
 import * as tasks from './tasks';
 import * as statusBar from './statusbar';
 import * as syntaxHighlighter from './highlighting';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 import * as tasks from './tasks';
 import * as statusBar from './statusbar';
 import * as syntaxHighlighter from './highlighting';
@@ -20,7 +20,6 @@ import * as vampir from './vampir/tasks';
 import * as codelens from './codelens';
 
 export async function activate(context: vscode.ExtensionContext) {
-  debugChannel.clear();
   statusBar.activate(context);
   codelens.activate(context);
   syntaxHighlighter.activate(context);
@@ -34,7 +33,4 @@ export async function activate(context: vscode.ExtensionContext) {
   formatter.activate(context);
   vampir.activate(context);
   dev.activate(context);
-  codelens.activate(context);
-  debugChannel.info('Juvix extension is ready!');
-
 }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from 'vscode';
 import { JuvixConfig } from './config';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 
 export function activate(_context: vscode.ExtensionContext) {
   const config = new JuvixConfig();
@@ -29,8 +29,7 @@ export function activate(_context: vscode.ExtensionContext) {
         '--with-comments',
       ].join(' ');
 
-      debugChannel.info(`Formatting ${filePath}`);
-      debugChannel.appendLine(formatterCall);
+      logger.trace(`Formatting ${filePath}\n${formatterCall}`, 'formatter.ts');
 
       const { spawnSync } = require('child_process');
       const ls = spawnSync(formatterCall, {
@@ -44,55 +43,11 @@ export function activate(_context: vscode.ExtensionContext) {
         return [vscode.TextEdit.replace(range, stdout)];
       } else {
         const errMsg: string = ls.stderr.toString();
+        logger.error('formatter provider error' + errMsg, 'formatter.ts');
         throw new Error(errMsg);
       }
     },
   });
-
-  // JuvixCore
-
-  // FIXME: one anoma/juvix/issue/#1841 is fixed.
-  // vscode.languages.registerDocumentFormattingEditProvider('JuvixCore', {
-  //   provideDocumentFormattingEdits(
-  //     document: vscode.TextDocument
-  //   ): vscode.TextEdit[] {
-  //     const range = new vscode.Range(
-  //       document.positionAt(0),
-  //       document.positionAt(document.getText().length)
-  //     );
-
-  //     const filePath = document.uri.fsPath;
-  //     debugChannel.appendLine(`Formatting ${filePath}`);
-  //     const formatterCall = [
-  //       config.getJuvixExec(),
-  //       config.getGlobalFlags(),
-  //       '--stdin',
-  //       'dev',
-  //       'core',
-  //       'read',
-  //       filePath,
-  //     ].join(' ');
-
-  //     debugChannel.appendLine(formatterCall);
-
-  //     const { spawnSync } = require('child_process');
-  //     const ls = spawnSync(formatterCall, {
-  //       shell: true,
-  //       input: document.getText(),
-  //       encoding: 'utf8',
-  //     });
-
-  //     debugChannel.appendLine(ls.stdout);
-
-  //     if (ls.status == 0) {
-  //       const stdout = ls.stdout;
-  //       return [vscode.TextEdit.replace(range, stdout)];
-  //     } else {
-  //       const errMsg: string = ls.stderr.toString();
-  //       throw new Error(errMsg);
-  //     }
-  //   },
-  // });
 
   // JuvixGeb
 
@@ -106,7 +61,7 @@ export function activate(_context: vscode.ExtensionContext) {
       );
 
       const filePath = document.uri.fsPath;
-      debugChannel.appendLine(`Formatting ${filePath}`);
+      logger.trace(`Formatting ${filePath}`, 'formatter.ts');
       const formatterCall = [
         config.getJuvixExec(),
         config.getGlobalFlags(),
@@ -117,7 +72,7 @@ export function activate(_context: vscode.ExtensionContext) {
         filePath,
       ].join(' ');
 
-      debugChannel.appendLine(formatterCall);
+      logger.appendLine(formatterCall);
 
       const { spawnSync } = require('child_process');
       const ls = spawnSync(formatterCall, {
@@ -126,7 +81,7 @@ export function activate(_context: vscode.ExtensionContext) {
         encoding: 'utf8',
       });
 
-      debugChannel.appendLine(ls.stdout);
+      logger.appendLine(ls.stdout);
 
       if (ls.status == 0) {
         const stdout = ls.stdout;

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -29,8 +29,6 @@ export function activate(_context: vscode.ExtensionContext) {
         '--with-comments',
       ].join(' ');
 
-      logger.trace(`Formatting ${filePath}\n${formatterCall}`, 'formatter.ts');
-
       const { spawnSync } = require('child_process');
       const ls = spawnSync(formatterCall, {
         shell: true,
@@ -49,8 +47,6 @@ export function activate(_context: vscode.ExtensionContext) {
     },
   });
 
-  // JuvixGeb
-
   vscode.languages.registerDocumentFormattingEditProvider('JuvixGeb', {
     provideDocumentFormattingEdits(
       document: vscode.TextDocument
@@ -61,7 +57,6 @@ export function activate(_context: vscode.ExtensionContext) {
       );
 
       const filePath = document.uri.fsPath;
-      logger.trace(`Formatting ${filePath}`, 'formatter.ts');
       const formatterCall = [
         config.getJuvixExec(),
         config.getGlobalFlags(),
@@ -72,16 +67,12 @@ export function activate(_context: vscode.ExtensionContext) {
         filePath,
       ].join(' ');
 
-      logger.appendLine(formatterCall);
-
       const { spawnSync } = require('child_process');
       const ls = spawnSync(formatterCall, {
         shell: true,
         input: document.getText(),
         encoding: 'utf8',
       });
-
-      logger.appendLine(ls.stdout);
 
       if (ls.status == 0) {
         const stdout = ls.stdout;

--- a/src/highlighting.ts
+++ b/src/highlighting.ts
@@ -6,7 +6,13 @@ import * as def from './definitions';
 import * as hover from './hover';
 import * as vscode from 'vscode';
 import { logger } from './utils/debug';
-import { FaceProperty, GotoProperty, RawInterval, DevHighlightOutput, HoverProperty } from './interfaces';
+import {
+  FaceProperty,
+  GotoProperty,
+  RawInterval,
+  DevHighlightOutput,
+  HoverProperty,
+} from './interfaces';
 import { JuvixConfig } from './config';
 import { spawnSync } from 'child_process';
 
@@ -45,9 +51,8 @@ export async function activate(context: vscode.ExtensionContext) {
     );
   } catch (error) {
     logger.error(
-      'Juvix: Could not register semantic syntax highlighter\n'
-      + error
-      , 'highlighting.ts'
+      'Juvix: Could not register semantic syntax highlighter\n' + error,
+      'highlighting.ts'
     );
   }
 }
@@ -84,7 +89,6 @@ export const legend: vscode.SemanticTokensLegend = (function () {
     tokenModifiersLegend
   );
 })();
-
 
 export class Highlighter implements vscode.DocumentSemanticTokensProvider {
   async provideDocumentSemanticTokens(
@@ -201,7 +205,6 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
     return builder.build();
   }
 
-
   private numberOfAstralSymbols(
     str: string,
     start: number,
@@ -241,7 +244,6 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
     }
     return 0;
   }
-
 
   private getFaceProperty(
     entry: ((string | number)[] | string)[]

--- a/src/highlighting.ts
+++ b/src/highlighting.ts
@@ -111,8 +111,6 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
       '--stdin',
     ].join(' ');
 
-    logger.trace('Highlighter call: ' + highlighterCall);
-
     const ls = spawnSync(highlighterCall, {
       input: content,
       shell: true,
@@ -121,13 +119,10 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
 
     if (ls.status !== 0) {
       const errMsg: string = "Juvix's Error: " + ls.stderr.toString();
-      vscode.window.showErrorMessage(errMsg);
-      throw new Error(errMsg);
+      logger.error(errMsg);
     }
     const stdout = ls.stdout;
     const output: DevHighlightOutput = JSON.parse(stdout.toString());
-
-    logger.trace('Highlighting output: ' + JSON.stringify(output, null, 2));
 
     /*
       Populate the location map for the Goto feature
@@ -169,7 +164,6 @@ export class Highlighter implements vscode.DocumentSemanticTokensProvider {
       The actual tokenization and syntax highlighting
     */
     const allTokens = output.face;
-    // log.debug('> Tokens length: ' + allTokens.length);
 
     const builder = new vscode.SemanticTokensBuilder(legend);
     allTokens.forEach(entry => {

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -16,16 +16,17 @@ export async function activate(_context: vscode.ExtensionContext) {
     vscode.languages.registerHoverProvider(
       { language: 'Juvix', scheme: 'file' },
       hoverProvider
-    )
+    );
   } catch (error) {
-    logger.error('No hover provider'+ error, 'hover.ts');
+    logger.error('No hover provider' + error, 'hover.ts');
   }
 }
 
 export class JuvixHoverProvider implements vscode.HoverProvider {
-  provideHover(document: vscode.TextDocument
-    , position: vscode.Position
-    , _token: vscode.CancellationToken
+  provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    _token: vscode.CancellationToken
   ) {
     const filePath: string = document.fileName;
     const line: number = position.line;
@@ -41,16 +42,25 @@ export class JuvixHoverProvider implements vscode.HoverProvider {
 
     for (let i = 0; i < hoversByLine.length; i++) {
       const hoverProperty: HoverProperty = hoversByLine[i];
-      if (hoverProperty.interval.startCol <= col && col <= hoverProperty.interval.endCol) {
-        let enhancedText = new vscode.MarkdownString(
-          hoverProperty.text
-        );
+      if (
+        hoverProperty.interval.startCol <= col &&
+        col <= hoverProperty.interval.endCol
+      ) {
+        let enhancedText = new vscode.MarkdownString(hoverProperty.text);
         enhancedText.isTrusted = true;
         enhancedText.supportHtml = true;
-        let hover = new vscode.Hover(enhancedText, new vscode.Range(
-          new vscode.Position(hoverProperty.interval.line, hoverProperty.interval.startCol),
-          new vscode.Position(hoverProperty.interval.endLine, hoverProperty.interval.endCol)
-        )
+        let hover = new vscode.Hover(
+          enhancedText,
+          new vscode.Range(
+            new vscode.Position(
+              hoverProperty.interval.line,
+              hoverProperty.interval.startCol
+            ),
+            new vscode.Position(
+              hoverProperty.interval.endLine,
+              hoverProperty.interval.endCol
+            )
+          )
         );
         return hover;
       }

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -17,12 +17,10 @@ export async function activate(_context: vscode.ExtensionContext) {
       { language: 'Juvix', scheme: 'file' },
       hoverProvider
     )
-    logger.trace('Hover info registered');
   } catch (error) {
-    logger.error('No hover provider'+ error);
+    logger.error('No hover provider'+ error, 'hover.ts');
   }
 }
-
 
 export class JuvixHoverProvider implements vscode.HoverProvider {
   provideHover(document: vscode.TextDocument
@@ -32,36 +30,18 @@ export class JuvixHoverProvider implements vscode.HoverProvider {
     const filePath: string = document.fileName;
     const line: number = position.line;
     const col: number = position.character;
-    // log.trace('Hover requested ------------------------');
-    // log.trace(
-    //   'info',
-    //   'In file: ' + filePath + ' at: ' + (line + 1) + ':' + (col + 1)
-    // );
     const hoversByFile = hoverMap.get(filePath);
     if (!hoversByFile) {
-      // log.trace(
-      //   'There is no hover info registered in file: ' + filePath
-      // );
       return undefined;
     }
     const hoversByLine = hoversByFile.get(line);
     if (!hoversByLine) {
-      // log.trace(
-      //   'There is no definitions registered in line: ' + (line + 1)
-      // );
       return undefined;
     }
-
-    // log.trace(
-    //   '> Found ' + hoversByLine.length + ' hovers at line: ' + (line + 1)
-    // );
 
     for (let i = 0; i < hoversByLine.length; i++) {
       const hoverProperty: HoverProperty = hoversByLine[i];
       if (hoverProperty.interval.startCol <= col && col <= hoverProperty.interval.endCol) {
-        logger.trace('info', 'Hover text: ' + hoverProperty.text);
-        logger.trace('info', 'Hover interval: ' + JSON.stringify(hoverProperty.interval));
-        logger.trace('col', col.toString());
         let enhancedText = new vscode.MarkdownString(
           hoverProperty.text
         );

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 import { RawInterval, HoverProperty } from './interfaces';
 
 export let hoverProvider: vscode.HoverProvider;
@@ -17,9 +17,9 @@ export async function activate(_context: vscode.ExtensionContext) {
       { language: 'Juvix', scheme: 'file' },
       hoverProvider
     )
-    debugChannel.info('Hover info registered');
+    logger.trace('Hover info registered');
   } catch (error) {
-    debugChannel.error('No hover provider', error);
+    logger.error('No hover provider'+ error);
   }
 }
 
@@ -32,36 +32,36 @@ export class JuvixHoverProvider implements vscode.HoverProvider {
     const filePath: string = document.fileName;
     const line: number = position.line;
     const col: number = position.character;
-    // debugChannel.info('Hover requested ------------------------');
-    // debugChannel.info(
+    // log.trace('Hover requested ------------------------');
+    // log.trace(
     //   'info',
     //   'In file: ' + filePath + ' at: ' + (line + 1) + ':' + (col + 1)
     // );
     const hoversByFile = hoverMap.get(filePath);
     if (!hoversByFile) {
-      // debugChannel.info(
+      // log.trace(
       //   'There is no hover info registered in file: ' + filePath
       // );
       return undefined;
     }
     const hoversByLine = hoversByFile.get(line);
     if (!hoversByLine) {
-      // debugChannel.info(
+      // log.trace(
       //   'There is no definitions registered in line: ' + (line + 1)
       // );
       return undefined;
     }
 
-    // debugChannel.info(
+    // log.trace(
     //   '> Found ' + hoversByLine.length + ' hovers at line: ' + (line + 1)
     // );
 
     for (let i = 0; i < hoversByLine.length; i++) {
       const hoverProperty: HoverProperty = hoversByLine[i];
       if (hoverProperty.interval.startCol <= col && col <= hoverProperty.interval.endCol) {
-        debugChannel.info('info', 'Hover text: ' + hoverProperty.text);
-        debugChannel.info('info', 'Hover interval: ' + JSON.stringify(hoverProperty.interval));
-        debugChannel.info('col', col.toString());
+        logger.trace('info', 'Hover text: ' + hoverProperty.text);
+        logger.trace('info', 'Hover interval: ' + JSON.stringify(hoverProperty.interval));
+        logger.trace('col', col.toString());
         let enhancedText = new vscode.MarkdownString(
           hoverProperty.text
         );

--- a/src/input.ts
+++ b/src/input.ts
@@ -19,7 +19,6 @@ import { logger } from './utils/debug';
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(new Abbr());
-  logger.trace('Abbreviation rewriter registered');
 }
 
 class Abbr {

--- a/src/input.ts
+++ b/src/input.ts
@@ -15,11 +15,11 @@ import { AbbreviationProvider } from './abbreviation/AbbreviationProvider';
 import { AbbreviationRewriter } from './abbreviation/rewriter/AbbreviationRewriter';
 import { autorunDisposable } from './utils/autorunDisposable';
 import { Disposable, languages, TextEditor, window } from 'vscode';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(new Abbr());
-  debugChannel.info('Abbreviation rewriter registered');
+  logger.trace('Abbreviation rewriter registered');
 }
 
 class Abbr {
@@ -47,7 +47,7 @@ class Abbr {
         this.config,
         this.table,
         currentEditor,
-        debugChannel
+        logger.outputChannel
       );
       this.disposables.push(rewriter);
     }
@@ -58,7 +58,7 @@ class Abbr {
           this.config,
           this.table,
           editor,
-          debugChannel
+          logger.outputChannel
         );
         this.disposables.push(rewriter);
       }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,8 +2,6 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import * as vscode from 'vscode';
-
 export interface RawInterval {
     file: string;
     line: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,30 +3,29 @@
  *--------------------------------------------------------*/
 
 export interface RawInterval {
-    file: string;
-    line: number;
-    startCol: number;
-    length: number;
-    endLine: number;
-    endCol: number;
-  }
+  file: string;
+  line: number;
+  startCol: number;
+  length: number;
+  endLine: number;
+  endCol: number;
+}
 
-  export interface FaceProperty {
-    interval: RawInterval;
-    tokenType: string;
-  }
+export interface FaceProperty {
+  interval: RawInterval;
+  tokenType: string;
+}
 
-  export interface HoverProperty {
-    interval: RawInterval;
-    text: string;
-  }
+export interface HoverProperty {
+  interval: RawInterval;
+  text: string;
+}
 
-  export interface DevHighlightOutput {
-    face: [Array<Array<string | number> | string>];
-    goto: [[string, number, number, number], string, number, number][];
-    doc: [[string, number, number, number,number, number], string][];
-  }
-
+export interface DevHighlightOutput {
+  face: [Array<Array<string | number> | string>];
+  goto: [[string, number, number, number], string, number, number][];
+  doc: [[string, number, number, number, number, number], string][];
+}
 
 export interface ColInterval {
   start: number;

--- a/src/judoc.ts
+++ b/src/judoc.ts
@@ -199,8 +199,7 @@ export class JudocPanel {
 
     const { spawnSync } = require('child_process');
 
-    const vscodePrefix =
-      webview.asWebviewUri(judocDocFolderUri).toString();
+    const vscodePrefix = webview.asWebviewUri(judocDocFolderUri).toString();
     const config = new JuvixConfig();
     const judocCall = [
       config.getJuvixExec(),
@@ -242,12 +241,12 @@ export class JudocPanel {
     return contentDisk.replace(
       '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">',
       '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src ' +
-      webview.cspSource +
-      '; img-src ' +
-      webview.cspSource +
-      " https:; script-src 'nonce-" +
-      nonce +
-      '\';">'
+        webview.cspSource +
+        '; img-src ' +
+        webview.cspSource +
+        " https:; script-src 'nonce-" +
+        nonce +
+        '\';">'
     );
   }
 }

--- a/src/judoc.ts
+++ b/src/judoc.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 import { JuvixConfig } from './config';
 import { isJuvixFile } from './utils/base';
 import * as path from 'path';
@@ -218,7 +218,7 @@ export class JudocPanel {
       doc.uri.fsPath,
     ].join(' ');
 
-    debugChannel.info('Judoc call', judocCall);
+    logger.trace('Judoc call', judocCall);
 
     const ls = spawnSync(judocCall, {
       shell: true,
@@ -227,7 +227,7 @@ export class JudocPanel {
 
     if (ls.status !== 0) {
       const errMsg: string = "Juvix's Error: " + ls.stderr.toString();
-      debugChannel.error('Judoc failed', errMsg);
+      logger.error('Judoc failed', errMsg);
       throw new Error(errMsg);
     }
     const htmlFilename = getModuleName(doc) + '.html';
@@ -237,7 +237,7 @@ export class JudocPanel {
       htmlFilename
     ).fsPath;
 
-    debugChannel.info('Rendering html file: ', htmlByJudocForDoc);
+    logger.trace('Rendering html file: ', htmlByJudocForDoc);
 
     const contentDisk: string = fs.readFileSync(htmlByJudocForDoc, 'utf8');
 

--- a/src/judoc.ts
+++ b/src/judoc.ts
@@ -218,8 +218,6 @@ export class JudocPanel {
       doc.uri.fsPath,
     ].join(' ');
 
-    logger.trace('Judoc call', judocCall);
-
     const ls = spawnSync(judocCall, {
       shell: true,
       encoding: 'utf8',
@@ -227,8 +225,7 @@ export class JudocPanel {
 
     if (ls.status !== 0) {
       const errMsg: string = "Juvix's Error: " + ls.stderr.toString();
-      logger.error('Judoc failed', errMsg);
-      throw new Error(errMsg);
+      logger.error(errMsg, 'judoc');
     }
     const htmlFilename = getModuleName(doc) + '.html';
 
@@ -236,8 +233,6 @@ export class JudocPanel {
       judocDocFolderUri,
       htmlFilename
     ).fsPath;
-
-    logger.trace('Rendering html file: ', htmlByJudocForDoc);
 
     const contentDisk: string = fs.readFileSync(htmlByJudocForDoc, 'utf8');
 

--- a/src/juvixVersion.ts
+++ b/src/juvixVersion.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 import * as vscode from 'vscode';
 
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 import * as user from './config';
 import * as utils from './utils/base';
 import * as versioning from 'compare-versions';
@@ -19,7 +19,7 @@ export function getInstalledFullVersion(): string | undefined {
   const ls = spawnSync(config.getJuvixExec(), ['--version']);
   let execJuvixVersion: string;
   if (ls.status !== 0) {
-    debugChannel.error(ERROR_JUVIX_NOT_INSTALLED);
+    logger.error(ERROR_JUVIX_NOT_INSTALLED);
     return;
   } else {
     execJuvixVersion = ls.stdout.toString().replace('version ', 'v');
@@ -34,7 +34,7 @@ export function getInstalledNumericVersion(): string | undefined {
   const ls = spawnSync(config.getJuvixExec(), ['--numeric-version']);
   let execJuvixVersion: string;
   if (ls.status !== 0) {
-    debugChannel.error(ERROR_JUVIX_NOT_INSTALLED);
+    logger.error(ERROR_JUVIX_NOT_INSTALLED);
     return;
   } else {
     execJuvixVersion = ls.stdout.toString().split('\n')[0];
@@ -50,8 +50,8 @@ export function isJuvixVersionSupported(): boolean {
   // Read Juvix version from file juvix.version
   const installedVersion = getInstalledNumericVersion();
   if (installedVersion) {
-    debugChannel.info('Juvix version installed: ' + installedVersion);
-    debugChannel.info('Juvix version supported: ' + supportedVersion);
+    logger.trace('Juvix version installed: ' + installedVersion);
+    logger.trace('Juvix version supported: ' + supportedVersion);
     return versioning.satisfies(installedVersion, '>=' + supportedVersion);
   } else {
     return false;

--- a/src/juvixVersion.ts
+++ b/src/juvixVersion.ts
@@ -1,45 +1,39 @@
 /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
-import * as vscode from 'vscode';
-
 import { logger } from './utils/debug';
-import * as user from './config';
-import * as utils from './utils/base';
+import { JuvixConfig } from './config';
 import * as versioning from 'compare-versions';
 import * as fs from 'fs';
 import * as path from 'path';
+import { spawnSync } from 'child_process';
 
-const ERROR_JUVIX_NOT_INSTALLED =
-  'Juvix binary is not installed. Please check the binary path in the configuration page or the instructions on https://docs.juvix.org/howto/installing.html';
+const ERROR_JUVIX_NOT_INSTALLED = [
+  'Juvix binary is not installed. Please check the binary path in the',
+  'configuration page or the instructions on',
+  'https://docs.juvix.org/howto/installing.html'
+].join(' ');
 
 export function getInstalledFullVersion(): string | undefined {
-  const config = new user.JuvixConfig();
-  const { spawnSync } = require('child_process');
+  const config = new JuvixConfig();
   const ls = spawnSync(config.getJuvixExec(), ['--version']);
-  let execJuvixVersion: string;
+
   if (ls.status !== 0) {
     logger.error(ERROR_JUVIX_NOT_INSTALLED);
     return;
-  } else {
-    execJuvixVersion = ls.stdout.toString().replace('version ', 'v');
-    const juvixBinaryVersion: string = execJuvixVersion.split('\n')[0];
-    return juvixBinaryVersion;
   }
+
+  return ls.stdout.toString().replace('version ', 'v').split('\n')[0];
 }
 
 export function getInstalledNumericVersion(): string | undefined {
-  const config = new user.JuvixConfig();
-  const { spawnSync } = require('child_process');
+  const config = new JuvixConfig();
   const ls = spawnSync(config.getJuvixExec(), ['--numeric-version']);
-  let execJuvixVersion: string;
   if (ls.status !== 0) {
     logger.error(ERROR_JUVIX_NOT_INSTALLED);
     return;
-  } else {
-    execJuvixVersion = ls.stdout.toString().split('\n')[0];
-    return execJuvixVersion;
   }
+  return ls.stdout.toString().split('\n')[0];
 }
 
 export const supportedVersion: string = fs
@@ -47,13 +41,6 @@ export const supportedVersion: string = fs
   .trim();
 
 export function isJuvixVersionSupported(): boolean {
-  // Read Juvix version from file juvix.version
   const installedVersion = getInstalledNumericVersion();
-  if (installedVersion) {
-    logger.trace('Juvix version installed: ' + installedVersion);
-    logger.trace('Juvix version supported: ' + supportedVersion);
-    return versioning.satisfies(installedVersion, '>=' + supportedVersion);
-  } else {
-    return false;
-  }
+  return installedVersion ? versioning.satisfies(installedVersion, `>=${supportedVersion}`) : false;
 }

--- a/src/juvixVersion.ts
+++ b/src/juvixVersion.ts
@@ -11,7 +11,7 @@ import { spawnSync } from 'child_process';
 const ERROR_JUVIX_NOT_INSTALLED = [
   'Juvix binary is not installed. Please check the binary path in the',
   'configuration page or the instructions on',
-  'https://docs.juvix.org/howto/installing.html'
+  'https://docs.juvix.org/howto/installing.html',
 ].join(' ');
 
 export function getInstalledFullVersion(): string | undefined {
@@ -42,5 +42,7 @@ export const supportedVersion: string = fs
 
 export function isJuvixVersionSupported(): boolean {
   const installedVersion = getInstalledNumericVersion();
-  return installedVersion ? versioning.satisfies(installedVersion, `>=${supportedVersion}`) : false;
+  return installedVersion
+    ? versioning.satisfies(installedVersion, `>=${supportedVersion}`)
+    : false;
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,15 +6,20 @@ import { juvixRoot, isUsingGlobalRoot } from './root';
 import * as path from 'path';
 import { isJuvixFile } from './utils/base';
 
-export function getModuleName(document: vscode.TextDocument): string | undefined {
-    if (!isJuvixFile(document)) return undefined;
-    const projRoot = juvixRoot();
-    if (!projRoot) {
-        return undefined;
-    }
-    const parsedFilepath = path.parse(document.fileName);
-    const moduleName = isUsingGlobalRoot(document)
-        ? parsedFilepath.name
-        : `${path.relative(projRoot, parsedFilepath.dir).split(path.sep).join('.')}.${parsedFilepath.name}`;
-    return moduleName;
+export function getModuleName(
+  document: vscode.TextDocument
+): string | undefined {
+  if (!isJuvixFile(document)) return undefined;
+  const projRoot = juvixRoot();
+  if (!projRoot) {
+    return undefined;
+  }
+  const parsedFilepath = path.parse(document.fileName);
+  const moduleName = isUsingGlobalRoot(document)
+    ? parsedFilepath.name
+    : `${path
+        .relative(projRoot, parsedFilepath.dir)
+        .split(path.sep)
+        .join('.')}.${parsedFilepath.name}`;
+  return moduleName;
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,22 +5,16 @@ import * as vscode from 'vscode';
 import { juvixRoot, isUsingGlobalRoot } from './root';
 import * as path from 'path';
 import { isJuvixFile } from './utils/base';
-import { logger as logger } from './utils/debug';
 
 export function getModuleName(document: vscode.TextDocument): string | undefined {
     if (!isJuvixFile(document)) return undefined;
     const projRoot = juvixRoot();
-    logger.trace(`Document: ${document.fileName}`, "module.ts");
-    logger.trace(`Project root: ${projRoot}`, "module.ts");
     if (!projRoot) {
-        logger.error("Juvix's Error: Cannot find Juvix root", "module.ts");
         return undefined;
     }
-    logger.trace(`Using Juvix root: ${projRoot}`, "module.ts");
     const parsedFilepath = path.parse(document.fileName);
     const moduleName = isUsingGlobalRoot(document)
         ? parsedFilepath.name
         : `${path.relative(projRoot, parsedFilepath.dir).split(path.sep).join('.')}.${parsedFilepath.name}`;
-    logger.trace(`Module name: ${moduleName}`, "module.ts");
     return moduleName;
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -5,24 +5,22 @@ import * as vscode from 'vscode';
 import { juvixRoot, isUsingGlobalRoot } from './root';
 import * as path from 'path';
 import { isJuvixFile } from './utils/base';
-
+import { logger as logger } from './utils/debug';
 
 export function getModuleName(document: vscode.TextDocument): string | undefined {
-
+    if (!isJuvixFile(document)) return undefined;
     const projRoot = juvixRoot();
-    const parsedFilepath = path.parse(document.fileName);
-    if (!isJuvixFile(document)) {
+    logger.trace(`Document: ${document.fileName}`, "module.ts");
+    logger.trace(`Project root: ${projRoot}`, "module.ts");
+    if (!projRoot) {
+        logger.error("Juvix's Error: Cannot find Juvix root", "module.ts");
         return undefined;
     }
-    let moduleName: string | undefined = undefined;
-    if (isUsingGlobalRoot(document)) {
-        moduleName = parsedFilepath.name;
-    } else {
-        let relativeModulePath: string =
-            path.relative(projRoot, parsedFilepath.dir).replace(path.sep, ".");
-        moduleName =
-            `${relativeModulePath}${relativeModulePath.length > 0 ? '.' : ''}${parsedFilepath.name}`;
-    }
+    logger.trace(`Using Juvix root: ${projRoot}`, "module.ts");
+    const parsedFilepath = path.parse(document.fileName);
+    const moduleName = isUsingGlobalRoot(document)
+        ? parsedFilepath.name
+        : `${path.relative(projRoot, parsedFilepath.dir).split(path.sep).join('.')}.${parsedFilepath.name}`;
+    logger.trace(`Module name: ${moduleName}`, "module.ts");
     return moduleName;
-
 }

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -29,12 +29,8 @@ export class JuvixRepl {
   public document: vscode.TextDocument;
 
   constructor(document: vscode.TextDocument) {
-    logger.trace('Creating Juvix REPL');
     this.config = new JuvixConfig();
-
     this.document = document;
-    logger.trace('document: ' + document.fileName);
-
     const options: vscode.TerminalOptions = {
       name: terminalName,
       cwd: path.dirname(document.fileName),
@@ -44,7 +40,6 @@ export class JuvixRepl {
         preserveFocus: true,
       },
     };
-    logger.trace('options: ' + JSON.stringify(options));
     this.terminal = vscode.window.createTerminal(options);
     this.openRepl();
 
@@ -103,7 +98,6 @@ export class JuvixRepl {
       logger.error('Unknown language', 'repl.ts');
       return;
     }
-    logger.trace('Opening REPL with command: ' + shellCmd);
     const ready: Promise<vscode.TerminalExitStatus> =
       this.promiseCall(shellCmd);
     ready.then(status => {
@@ -111,7 +105,6 @@ export class JuvixRepl {
         this.terminal.show();
         this.ready = true;
       } else {
-        logger.trace('Juvix REPL was closed', 'repl.ts');
         this.ready = false;
       }
     });
@@ -120,16 +113,13 @@ export class JuvixRepl {
   /* Load the current file in the REPL */
   public loadFileRepl(): void {
     const filename = this.document.fileName;
-    logger.trace('Loading file in REPL: ' + filename);
     if (canRunRepl(this.document)) this.document.save();
     if (isJuvixFile(this.document)) {
       if (!this.reloadNextTime) this.terminal.sendText(`:load ${filename}`);
       else this.terminal.sendText(`\n:reload ${filename}`);
     } else if (isJuvixCoreFile(this.document)) {
-      logger.trace('Loading to the Repl a Juvix Core file');
       this.terminal.sendText(`:l ${filename}`);
     } else if (isJuvixGebFile(this.document)) {
-      logger.trace('Loading to the Repl a Juvix Geb file');
       this.terminal.sendText(`:l ${filename}`);
     } else return;
     this.reloadNextTime = true;
@@ -137,12 +127,10 @@ export class JuvixRepl {
   }
 
   public sendText(msg: string): void {
-    logger.trace('Sending text to REPL: ' + msg);
     this.terminal.sendText(msg);
   }
 
   public dispose(): void {
-    logger.trace('Disposing Juvix REPL');
     this.terminal.dispose();
     for (const disposable of this.disposables) disposable.dispose();
   }
@@ -206,7 +194,6 @@ export async function activate(context: vscode.ExtensionContext) {
         repl?.dispose();
         repl = new JuvixRepl(document);
       }
-      logger.trace('repl: ' + repl.document.fileName);
       repl.loadFileRepl();
     }
   );

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 import * as vscode from 'vscode';
 import { JuvixConfig } from './config';
 import { observable } from 'mobx';
@@ -29,11 +29,11 @@ export class JuvixRepl {
   public document: vscode.TextDocument;
 
   constructor(document: vscode.TextDocument) {
-    debugChannel.info('Creating Juvix REPL');
+    logger.trace('Creating Juvix REPL');
     this.config = new JuvixConfig();
 
     this.document = document;
-    debugChannel.info('document: ' + document.fileName);
+    logger.trace('document: ' + document.fileName);
 
     const options: vscode.TerminalOptions = {
       name: terminalName,
@@ -44,7 +44,7 @@ export class JuvixRepl {
         preserveFocus: true,
       },
     };
-    debugChannel.info('options: ' + JSON.stringify(options));
+    logger.trace('options: ' + JSON.stringify(options));
     this.terminal = vscode.window.createTerminal(options);
     this.openRepl();
 
@@ -92,28 +92,26 @@ export class JuvixRepl {
 
   /* Open the REPL for the current file */
   public openRepl(): void {
-    debugChannel.info('Exec juvix repl');
     let shellCmd = this.config.getJuvixExec();
     if (isJuvixFile(this.document)) {
       shellCmd += ' ' + 'repl';
     } else if (isJuvixCoreFile(this.document)) {
       shellCmd += ' ' + 'dev core repl';
     } else if (isJuvixGebFile(this.document)) {
-      debugChannel.info('Geb repl');
       shellCmd += ' ' + 'dev geb repl';
     } else {
-      debugChannel.error('Unknown language');
+      logger.error('Unknown language', 'repl.ts');
       return;
     }
+    logger.trace('Opening REPL with command: ' + shellCmd);
     const ready: Promise<vscode.TerminalExitStatus> =
       this.promiseCall(shellCmd);
     ready.then(status => {
       if (status.code == 0) {
-        vscode.window.showInformationMessage('Juvix REPL ready');
         this.terminal.show();
         this.ready = true;
       } else {
-        debugChannel.info('Juvix REPL was closed:', status.code);
+        logger.trace('Juvix REPL was closed', 'repl.ts');
         this.ready = false;
       }
     });
@@ -122,16 +120,16 @@ export class JuvixRepl {
   /* Load the current file in the REPL */
   public loadFileRepl(): void {
     const filename = this.document.fileName;
-    debugChannel.info('Loading file in REPL: ' + filename);
+    logger.trace('Loading file in REPL: ' + filename);
     if (canRunRepl(this.document)) this.document.save();
     if (isJuvixFile(this.document)) {
       if (!this.reloadNextTime) this.terminal.sendText(`:load ${filename}`);
       else this.terminal.sendText(`\n:reload ${filename}`);
     } else if (isJuvixCoreFile(this.document)) {
-      debugChannel.info('Loading to the Repl a Juvix Core file');
+      logger.trace('Loading to the Repl a Juvix Core file');
       this.terminal.sendText(`:l ${filename}`);
     } else if (isJuvixGebFile(this.document)) {
-      debugChannel.info('Loading to the Repl a Juvix Geb file');
+      logger.trace('Loading to the Repl a Juvix Geb file');
       this.terminal.sendText(`:l ${filename}`);
     } else return;
     this.reloadNextTime = true;
@@ -139,12 +137,12 @@ export class JuvixRepl {
   }
 
   public sendText(msg: string): void {
-    debugChannel.info('Sending text to REPL: ' + msg);
+    logger.trace('Sending text to REPL: ' + msg);
     this.terminal.sendText(msg);
   }
 
   public dispose(): void {
-    debugChannel.info('Disposing Juvix REPL');
+    logger.trace('Disposing Juvix REPL');
     this.terminal.dispose();
     for (const disposable of this.disposables) disposable.dispose();
   }
@@ -208,7 +206,7 @@ export async function activate(context: vscode.ExtensionContext) {
         repl?.dispose();
         repl = new JuvixRepl(document);
       }
-      debugChannel.info('repl: ' + repl.document.fileName);
+      logger.trace('repl: ' + repl.document.fileName);
       repl.loadFileRepl();
     }
   );

--- a/src/root.ts
+++ b/src/root.ts
@@ -8,30 +8,43 @@ import { getInstalledNumericVersion } from './juvixVersion';
 import * as path from 'path';
 import { isJuvixFile } from './utils/base';
 
-export function juvixRoot(document: vscode.TextDocument | undefined = undefined): string | undefined {
-    const { spawnSync } = require('child_process');
-    const doc: vscode.TextDocument | undefined = document ?? vscode.window.activeTextEditor?.document;
-    if (!doc || !isJuvixFile(doc)) {
-        return undefined;
-    }
-    const juvixRootCall = `${config.getJuvixExec()} dev root ${doc.uri.fsPath}`;
-    const { status, stderr, stdout } = spawnSync(juvixRootCall, { shell: true, encoding: 'utf8' });
-    if (status !== 0) {
-        logger.error(stderr.toString(), "root.ts");
-        return undefined;
-    }
-    const root: string = stdout.toString().trim();
-    return root;
+export function juvixRoot(
+  document: vscode.TextDocument | undefined = undefined
+): string | undefined {
+  const { spawnSync } = require('child_process');
+  const doc: vscode.TextDocument | undefined =
+    document ?? vscode.window.activeTextEditor?.document;
+  if (!doc || !isJuvixFile(doc)) {
+    return undefined;
+  }
+  const juvixRootCall = `${config.getJuvixExec()} dev root ${doc.uri.fsPath}`;
+  const { status, stderr, stdout } = spawnSync(juvixRootCall, {
+    shell: true,
+    encoding: 'utf8',
+  });
+  if (status !== 0) {
+    logger.error(stderr.toString(), 'root.ts');
+    return undefined;
+  }
+  const root: string = stdout.toString().trim();
+  return root;
 }
 
 export function globalJuvixRoot(): string {
-    const juvixVersion = getInstalledNumericVersion();
-    const { HOME } = process.env;
-    const rootPath = path.join(HOME ?? '', '.config', 'juvix', juvixVersion ?? '', 'global-project', path.sep);
-    return rootPath;
+  const juvixVersion = getInstalledNumericVersion();
+  const { HOME } = process.env;
+  const rootPath = path.join(
+    HOME ?? '',
+    '.config',
+    'juvix',
+    juvixVersion ?? '',
+    'global-project',
+    path.sep
+  );
+  return rootPath;
 }
 
 export function isUsingGlobalRoot(doc: vscode.TextDocument): boolean {
-    if (!isJuvixFile(doc)) return false;
-    return juvixRoot() === globalJuvixRoot();
+  if (!isJuvixFile(doc)) return false;
+  return juvixRoot() === globalJuvixRoot();
 }

--- a/src/root.ts
+++ b/src/root.ts
@@ -2,53 +2,41 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 import * as vscode from 'vscode';
-import { debugChannel } from './utils/debug';
-import { JuvixConfig } from './config';
+import { logger } from './utils/debug';
+import { config } from './config';
 import { getInstalledNumericVersion } from './juvixVersion';
 import * as path from 'path';
 import { isJuvixFile } from './utils/base';
 
-export function juvixRoot() {
-    const config = new JuvixConfig();
+export function juvixRoot(document: vscode.TextDocument | undefined = undefined): string | undefined {
     const { spawnSync } = require('child_process');
-    const doc = vscode.window.activeTextEditor?.document;
-    if (doc) {
-        const juvixRootCall = [
-            config.getJuvixExec(),
-            config.getGlobalFlags(),
-            'dev',
-            'root',
-            doc.uri.fsPath,
-        ].join(' ');
-
-        const rootRun = spawnSync(juvixRootCall, { shell: true, encoding: 'utf8' });
-        if (rootRun.status !== 0) {
-            const errMsg: string = "Juvix's Error: " + rootRun.stderr.toString();
-            debugChannel.error('Juvix root failed for Judoc gen:', errMsg);
-            throw new Error(errMsg);
-        }
-        return rootRun.stdout.toString().trim();
+    const doc: vscode.TextDocument | undefined = document ?? vscode.window.activeTextEditor?.document;
+    if (!doc || !isJuvixFile(doc)) {
+        return undefined;
     }
-    return undefined;
+    const juvixRootCall = `${config.getJuvixExec()} dev root ${doc.uri.fsPath}`;
+    logger.trace(`Getting Juvix root for ${doc.uri.fsPath}`, "root.ts");
+    logger.trace(`Juvix root call: ${juvixRootCall}`, "root.ts");
+
+    const { status, stderr, stdout } = spawnSync(juvixRootCall, { shell: true, encoding: 'utf8' });
+    if (status !== 0) {
+        logger.error(stderr.toString(), "root.ts");
+        return undefined;
+    }
+    const root: string = stdout.toString().trim();
+    logger.trace(`Juvix root: ${root}`, "root.ts");
+    return root;
 }
 
-export function globalJuvixRoot() : string {
+export function globalJuvixRoot(): string {
     const juvixVersion = getInstalledNumericVersion();
-    const homeUserPath = process.env.HOME;
-    if (!homeUserPath) {
-        throw new Error('Cannot find home directory');
-    }
-    if (!juvixVersion) {
-        throw new Error('Cannot find Juvix version');
-    }
-    return path.join(homeUserPath, '.config', 'juvix', juvixVersion, 'global-project', path.sep);
+    const { HOME } = process.env;
+    const rootPath = path.join(HOME ?? '', '.config', 'juvix', juvixVersion ?? '', 'global-project', path.sep);
+    logger.trace(`Global Juvix root: ${rootPath}`, "root.ts");
+    return rootPath;
 }
 
-export function isUsingGlobalRoot(doc: vscode.TextDocument) : boolean {
-    if (doc && isJuvixFile(doc)) {
-        const projRoot = juvixRoot();
-        const globalProjRoot = globalJuvixRoot();
-        return projRoot == globalProjRoot;
-    }
-    return false;
+export function isUsingGlobalRoot(doc: vscode.TextDocument): boolean {
+    if (!isJuvixFile(doc)) return false;
+    return juvixRoot() === globalJuvixRoot();
 }

--- a/src/root.ts
+++ b/src/root.ts
@@ -15,16 +15,12 @@ export function juvixRoot(document: vscode.TextDocument | undefined = undefined)
         return undefined;
     }
     const juvixRootCall = `${config.getJuvixExec()} dev root ${doc.uri.fsPath}`;
-    logger.trace(`Getting Juvix root for ${doc.uri.fsPath}`, "root.ts");
-    logger.trace(`Juvix root call: ${juvixRootCall}`, "root.ts");
-
     const { status, stderr, stdout } = spawnSync(juvixRootCall, { shell: true, encoding: 'utf8' });
     if (status !== 0) {
         logger.error(stderr.toString(), "root.ts");
         return undefined;
     }
     const root: string = stdout.toString().trim();
-    logger.trace(`Juvix root: ${root}`, "root.ts");
     return root;
 }
 
@@ -32,7 +28,6 @@ export function globalJuvixRoot(): string {
     const juvixVersion = getInstalledNumericVersion();
     const { HOME } = process.env;
     const rootPath = path.join(HOME ?? '', '.config', 'juvix', juvixVersion ?? '', 'global-project', path.sep);
-    logger.trace(`Global Juvix root: ${rootPath}`, "root.ts");
     return rootPath;
 }
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -41,16 +41,13 @@ export async function activate(context: vscode.ExtensionContext) {
           () => {
             const ex = vscode.tasks.executeTask(task);
             ex.then((v: vscode.TaskExecution) => {
-              logger.trace('Task "' + cmdName + '" executed');
               v.terminate();
               return true;
             });
-            logger.trace('Task "' + cmdName + '" executed');
             return false;
           }
         );
         context.subscriptions.push(cmd);
-        logger.trace('[!] "' + cmdName + '" command registered');
       }
     })
     .catch(err => {
@@ -159,8 +156,6 @@ export class JuvixTaskProvider implements vscode.TaskProvider {
       };
       tasks.push(vscodeTask);
     }
-    // log.trace('Tasks to be added:');
-    // log.trace(JSON.stringify(tasks).toString());
     return tasks;
   }
 
@@ -170,7 +165,6 @@ export class JuvixTaskProvider implements vscode.TaskProvider {
       const args = [definition.command].concat(definition.args ?? []);
       return await JuvixTask(definition, task.name, args);
     }
-    logger.warn('resolveTask: fail to resolve', task);
     return undefined;
   }
 }
@@ -206,7 +200,6 @@ export async function JuvixTask(
       const gebCompile =
         config.getGebExec() +
         ` -i ${fl}.lisp -e "${fl}::*entry*" -l -v -o ${fl}.pir`;
-      logger.trace(gebCompile);
       exec = new vscode.ShellExecution(gebCompile);
       break;
     case 'geb-eval':

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from 'vscode';
 import * as user from './config';
-import { debugChannel } from './utils/debug';
+import { logger } from './utils/debug';
 
 export const TASK_TYPE = 'Juvix';
 
@@ -21,7 +21,7 @@ export async function activate(context: vscode.ExtensionContext) {
       'Juvix extension requires at least one workspace open.\n' +
       'Open a folder containing a Juvix project and try again.';
     vscode.window.showErrorMessage(msg);
-    debugChannel.error(msg);
+    logger.error(msg);
     return;
   }
 
@@ -41,20 +41,20 @@ export async function activate(context: vscode.ExtensionContext) {
           () => {
             const ex = vscode.tasks.executeTask(task);
             ex.then((v: vscode.TaskExecution) => {
-              debugChannel.info('Task "' + cmdName + '" executed');
+              logger.trace('Task "' + cmdName + '" executed');
               v.terminate();
               return true;
             });
-            debugChannel.info('Task "' + cmdName + '" executed');
+            logger.trace('Task "' + cmdName + '" executed');
             return false;
           }
         );
         context.subscriptions.push(cmd);
-        debugChannel.info('[!] "' + cmdName + '" command registered');
+        logger.trace('[!] "' + cmdName + '" command registered');
       }
     })
     .catch(err => {
-      debugChannel.error('Task provider error: ' + err);
+      logger.error('Task provider error: ' + err);
     });
 }
 
@@ -159,8 +159,8 @@ export class JuvixTaskProvider implements vscode.TaskProvider {
       };
       tasks.push(vscodeTask);
     }
-    // debugChannel.info('Tasks to be added:');
-    // debugChannel.info(JSON.stringify(tasks).toString());
+    // log.trace('Tasks to be added:');
+    // log.trace(JSON.stringify(tasks).toString());
     return tasks;
   }
 
@@ -170,7 +170,7 @@ export class JuvixTaskProvider implements vscode.TaskProvider {
       const args = [definition.command].concat(definition.args ?? []);
       return await JuvixTask(definition, task.name, args);
     }
-    debugChannel.warn('resolveTask: fail to resolve', task);
+    logger.warn('resolveTask: fail to resolve', task);
     return undefined;
   }
 }
@@ -206,7 +206,7 @@ export async function JuvixTask(
       const gebCompile =
         config.getGebExec() +
         ` -i ${fl}.lisp -e "${fl}::*entry*" -l -v -o ${fl}.pir`;
-      debugChannel.info(gebCompile);
+      logger.trace(gebCompile);
       exec = new vscode.ShellExecution(gebCompile);
       break;
     case 'geb-eval':

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -2,7 +2,7 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { debugChannel } from './debug';
+import { logger } from './debug';
 
 /*
  * Adapted from vscode-lean sources.
@@ -12,7 +12,7 @@ import { debugChannel } from './debug';
 export function assert(condition: () => boolean): void {
   if (!condition()) {
     const msg = `Assert failed: "${condition.toString()}" must be true, but was not!`;
-    debugChannel.error(msg);
+    logger.error(msg);
     throw new Error(msg);
   }
 }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -7,8 +7,9 @@ class Log {
   public outputChannel: vscode.LogOutputChannel;
 
   constructor() {
-    this.outputChannel = vscode.window.createOutputChannel('Juvix Extension',
-      { log: true });
+    this.outputChannel = vscode.window.createOutputChannel('Juvix Extension', {
+      log: true,
+    });
   }
 
   private logString(message: string, component?: string) {

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -3,5 +3,42 @@
  *--------------------------------------------------------*/
 import * as vscode from 'vscode';
 
-export const debugChannel: vscode.LogOutputChannel =
-  vscode.window.createOutputChannel('Juvix Extension Debug', { log: true });
+class Log {
+  public outputChannel: vscode.LogOutputChannel;
+
+  constructor() {
+    this.outputChannel = vscode.window.createOutputChannel('Juvix Extension',
+      { log: true });
+  }
+
+  private logString(message: string, component?: string) {
+    return component ? `${component}> ${message}` : message;
+  }
+
+  public trace(message: string, component?: string) {
+    this.outputChannel.trace(this.logString(message, component));
+  }
+
+  public debug(message: string, component?: string) {
+    this.outputChannel.debug(this.logString(message, component));
+  }
+
+  public appendLine(message: string, component?: string) {
+    this.outputChannel.info(this.logString(message, component));
+  }
+
+  public warn(message: string, component?: string) {
+    const msg = this.logString(message, component);
+    this.outputChannel.error(msg);
+    vscode.window.showWarningMessage(msg);
+  }
+
+  public error(message: string, component?: string) {
+    const msg = this.logString(message, component);
+    this.outputChannel.error(msg);
+    vscode.window.showErrorMessage(msg);
+    throw new Error(msg);
+  }
+}
+
+export const logger = new Log();

--- a/src/utils/fromResource.ts
+++ b/src/utils/fromResource.ts
@@ -9,7 +9,7 @@
 
 import { createAtom, _allowStateChanges } from 'mobx';
 import { Disposable } from 'vscode';
-import { debugChannel } from './debug';
+import { logger } from './debug';
 
 function invariant(_condition: boolean, _message?: string) {
   // Empty function
@@ -46,7 +46,7 @@ export function fromResource<T>(
           value = getValue();
         } else {
           const msg = 'Either an argument or getValue must be provided';
-          debugChannel.error(msg);
+          logger.error(msg);
           throw new Error(msg);
         }
         atom.reportChanged();
@@ -71,7 +71,7 @@ export function fromResource<T>(
         if (getValue) {
           return getValue();
         } else {
-          debugChannel.warn(
+          logger.warn(
             'Called `get` of a subscribingObservable outside a reaction. Current value will be returned but no new subscription has started'
           );
         }

--- a/src/vampir/tasks.ts
+++ b/src/vampir/tasks.ts
@@ -33,16 +33,13 @@ export async function activate(context: vscode.ExtensionContext) {
           () => {
             const ex = vscode.tasks.executeTask(task);
             ex.then((v: vscode.TaskExecution) => {
-              logger.trace('Task "' + cmdName + '" executed');
               v.terminate();
               return true;
             });
-            logger.trace('VampIR Task "' + cmdName + '" executed');
             return false;
           }
         );
         context.subscriptions.push(cmd);
-        logger.trace('[!] VampIR "' + cmdName + '" command registered');
       }
     })
     .catch(err => {
@@ -144,7 +141,6 @@ export class VampIRProvider implements vscode.TaskProvider {
       const args = [definition.command].concat(definition.args ?? []);
       return await VampIR(definition, task.name, args);
     }
-    logger.warn('resolveTask: fail to resolve', task);
     return undefined;
   }
 }

--- a/src/vampir/tasks.ts
+++ b/src/vampir/tasks.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { debugChannel } from '../utils/debug';
+import { logger } from '../utils/debug';
 import { JuvixConfig } from '../config';
 
 export const TASK_TYPE = 'VampIR';
@@ -13,7 +13,7 @@ export async function activate(context: vscode.ExtensionContext) {
   if (vscode.workspace.workspaceFolders === undefined) {
     const msg = 'VampIR extension requires at least one workspace open.\n';
     vscode.window.showErrorMessage(msg);
-    debugChannel.error(msg);
+    logger.error(msg);
     return;
   }
 
@@ -33,20 +33,20 @@ export async function activate(context: vscode.ExtensionContext) {
           () => {
             const ex = vscode.tasks.executeTask(task);
             ex.then((v: vscode.TaskExecution) => {
-              debugChannel.info('Task "' + cmdName + '" executed');
+              logger.trace('Task "' + cmdName + '" executed');
               v.terminate();
               return true;
             });
-            debugChannel.info('VampIR Task "' + cmdName + '" executed');
+            logger.trace('VampIR Task "' + cmdName + '" executed');
             return false;
           }
         );
         context.subscriptions.push(cmd);
-        debugChannel.info('[!] VampIR "' + cmdName + '" command registered');
+        logger.trace('[!] VampIR "' + cmdName + '" command registered');
       }
     })
     .catch(err => {
-      debugChannel.error('VampIR Task provider error: ' + err);
+      logger.error('VampIR Task provider error: ' + err);
     });
 }
 
@@ -144,7 +144,7 @@ export class VampIRProvider implements vscode.TaskProvider {
       const args = [definition.command].concat(definition.args ?? []);
       return await VampIR(definition, task.name, args);
     }
-    debugChannel.warn('resolveTask: fail to resolve', task);
+    logger.warn('resolveTask: fail to resolve', task);
     return undefined;
   }
 }


### PR DESCRIPTION
This PR is for codebase maintenance:

- change debugChannel by logger, nb. for errors use logger.error.
- delete all traces, if you need to debug you can use, e.g.: logger.trace|warn or the built-in debugger. Remember also set up the `developer log level`.
- remove dead code in several places
- simplify several (small) functions
- run js prettier
- fix a bug for module name discovery.
