### PR TITLE
Handle format command exit codes better

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -34,10 +34,16 @@ export function activate(_context: vscode.ExtensionContext) {
         encoding: 'utf8',
       });
 
+      // already formatted
       if (ls.status == 0) {
         const stdout = ls.stdout;
-        return [vscode.TextEdit.replace(range, stdout)];
+        return [];
       } else {
+        // not formatted and return the formatted stdout
+        if (ls.stdout != '') {
+          return [vscode.TextEdit.replace(range, ls.stdout)];
+        }
+        // else it is formatting error
         const errMsg: string = ls.stderr.toString();
         logger.error(errMsg, 'formatter.ts');
         return [];


### PR DESCRIPTION
- Resolves #98 

Now the behaviour is expected.

However, we might want to change exit code in the juvix itself for the `format` command. For example, return `0` when it successfully formats the document. What do you think @jonaprieto ?